### PR TITLE
feat(a2a-trust-header): APS Week 2 fixture set per A2A#1742

### DIFF
--- a/a2a-trust-header/README.md
+++ b/a2a-trust-header/README.md
@@ -1,0 +1,154 @@
+# a2a-trust-header — APS Week 2 fixtures
+
+Six signed, JCS-canonical fixtures for the `x-agent-trust` header being
+specified at [a2aproject/A2A#1742](https://github.com/a2aproject/A2A/issues/1742).
+The header carries trust signals about an agent across A2A calls so
+receiving agents can decide whether to honor the request.
+
+This directory is APS's contribution to the Week 2 cross-verification
+milestone. Format conventions were locked in the #1742 thread with
+@MoltyCel:
+
+- Happy-path cases use `delegation_chain_root: "sha256:<hex>"`.
+- Drift and revocation cases **must** carry `format_variant: true` at
+  the fixture level to explicitly flag any deviation from the canonical
+  shape.
+- Cases exercise both trust_level trajectories and the Agent Card
+  `trust.signals[]` cross-org pattern from [a2aproject/A2A#1628](https://github.com/a2aproject/A2A/issues/1628).
+
+## The six fixtures
+
+| # | File | Case | `format_variant` | expected_verifier_output |
+|---|------|------|---|---|
+| 1 | [`happy-path.json`](./happy-path.json) | Two-step delegation chain, monotonic narrowing, single `trusted` attestation | `false` | `valid` |
+| 2 | [`trust-level-ascending.json`](./trust-level-ascending.json) | Trajectory `unknown → developing → trusted` across three independently-signed attestations | `false` | `valid` |
+| 3 | [`trust-level-descending.json`](./trust-level-descending.json) | Reputation-decay trajectory `trusted → developing → flagged` | `false` | `valid` |
+| 4 | [`drift-explicit-flag.json`](./drift-explicit-flag.json) | Two attestations with the same chain but divergent root algorithm (`sha256` → `keccak256`) | **`true`** | `invalid` |
+| 5 | [`revocation-mid-chain.json`](./revocation-mid-chain.json) | Chain valid at T0, revoked at T1, use attempted at T2 produces a signed deny receipt | **`true`** | `deny` |
+| 6 | [`shared-card-crossorg.json`](./shared-card-crossorg.json) | A2A Agent Card (per #1628) with `trust.signals[]` from orgA and orgB about the same subject agent, no self-attestation | `false` | `valid` |
+
+## Fixture shape
+
+Every fixture is a single JSON object:
+
+```json
+{
+  "fixture": "<name>",
+  "description": "...",
+  "expected_verifier_output": "valid | invalid | deny",
+  "format_variant": true | false,
+  "format_variant_reason": "<only when format_variant=true>",
+  "spec_refs": ["a2aproject/A2A#1742", ...],
+  "header_name": "x-agent-trust",
+  "header_value": { ... the signed blob that would go into the header ... }
+}
+```
+
+`header_value` contains:
+
+- `trust_header_version` — `"0.1"` for this round.
+- `subject_agent` — `did:aps:<pubkey-prefix>` of the agent the header
+  is asserting about.
+- `delegation_chain` — ordered array of delegation links. Each link is
+  a JCS-canonical object with an Ed25519 signature from the principal.
+- `delegation_chain_root` — canonical form: `"sha256:<hex>"`. Computed
+  as `sha256(canonicalizeJCS(delegation_chain))`. Non-standard
+  algorithms (e.g., `keccak256:<hex>`) are permitted **only** in
+  fixtures that also carry `format_variant: true`.
+- `attestations` — ordered array of trust attestations. Each attestation
+  is `{ payload, signature }` where `signature` covers the JCS-canonical
+  `payload`. Attestations can be added by any issuer; self-attestation
+  (issuer == subject) is explicitly not used in these fixtures.
+- `agent_card` — present only in the shared-card fixture. Carries
+  `trust.signals[]` per A2A#1628.
+- `deny_receipt` — present only in the revocation fixture. A signed
+  record from the gateway/issuer refusing the use of a revoked
+  delegation, referenced from the corresponding attestation by
+  `deny_receipt_ref: "sha256:<hex>"`.
+
+## Crypto conventions
+
+- **Ed25519** signatures (RFC 8032).
+- **JCS** canonicalization (RFC 8785) over every signed payload.
+- **SHA-256** for `delegation_chain_root` (happy path) and for
+  `deny_receipt_ref`.
+- Every signature object is
+  `{ alg: "EdDSA", kid: "did:aps:<prefix>", pubkey: "<hex>", sig: "<hex>", canonicalization?: "RFC8785-JCS" }`.
+  The `canonicalization` field is present on attestations and on the
+  deny receipt; it's implied (JCS) on delegation links for brevity.
+
+## Deterministic keys
+
+Seeds are 32 bytes, right-aligned padding with zeros. The `aps_issuer`
+seed (`0x00...01`) matches the test key in `fixtures/keys/` so these
+fixtures can be cross-verified against the rest of the repo's vectors
+with the same keypair.
+
+| Role | Seed (tail) | Public key |
+|------|------|------|
+| `aps_issuer`    | `...01` | `4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29` |
+| `org_a`         | `...02` | see [`_keys.json`](./_keys.json) |
+| `org_b`         | `...03` | see [`_keys.json`](./_keys.json) |
+| `subject_agent` | `...04` | see [`_keys.json`](./_keys.json) |
+| `delegate_1`    | `...05` | see [`_keys.json`](./_keys.json) |
+| `delegate_2`    | `...06` | see [`_keys.json`](./_keys.json) |
+
+Private seeds are **not** included; verifiers only need the public
+halves. Implementations should re-derive public keys from the listed
+seed tails to confirm.
+
+## Verifier verdict rules
+
+A cross-verifier should assign a verdict per these rules (APS's
+reference implementation in [`verify.ts`](./verify.ts) encodes them):
+
+1. **`invalid`** — if any Ed25519 signature on a delegation link,
+   attestation, or deny receipt fails to verify.
+2. **`invalid`** — if attestations within the same header advertise
+   `delegation_chain_root` under more than one hash algorithm
+   (root-format drift).
+3. **`deny`** — if the delegation chain contains a `status: "revoked"`
+   link and a signed `deny_receipt` is attached.
+4. **`valid`** — otherwise. A descending `trust_level` trajectory is
+   still `valid`; the verifier's job is to surface the trajectory for
+   downstream policy to act on, not to fail the header.
+
+## Reproducing the fixtures
+
+```bash
+# From the repo root
+npx tsx a2a-trust-header/generate.ts
+# Round-trip verify
+npx tsx a2a-trust-header/verify.ts
+```
+
+`generate.ts` emits every fixture to disk with fixed timestamps and
+fixed seeds, so the six files are byte-reproducible. `verify.ts`
+re-canonicalizes every signed payload, checks every signature, and
+asserts the verdict matches `expected_verifier_output`.
+
+## Implementation notes
+
+- APS SDK used: `agent-passport-system@2.0.0`. The SDK exports
+  `canonicalizeJCS`, `sign`, `verify`, and `publicKeyFromPrivate`
+  from its top-level `src/index.ts`.
+- The generator does not mutate APS SDK source; it imports from the
+  published module path.
+- Every signed payload is a flat JSON object so JCS canonicalization is
+  unambiguous (no `undefined` values, no nested arrays of signable
+  primitives).
+- Timestamps (`issued_at`, `expires_at`, `revoked_at`, `attempted_at`)
+  are fixed ISO-8601 values between 2026-04-18T12:00:00Z and T+15min.
+  This keeps the fixtures reproducible while still exercising
+  time-ordered logic (e.g., revocation mid-chain).
+
+## Cross-implementation hook
+
+Any implementation can claim conformance with these fixtures by reading
+each file, re-canonicalizing every signed payload with an RFC 8785 JCS
+implementation, and verifying every Ed25519 signature against its
+advertised public key. The verdict for each fixture must match
+`expected_verifier_output`.
+
+Questions, format clarifications, or counter-examples: open a PR or
+comment on [a2aproject/A2A#1742](https://github.com/a2aproject/A2A/issues/1742).

--- a/a2a-trust-header/_keys.json
+++ b/a2a-trust-header/_keys.json
@@ -1,0 +1,29 @@
+{
+  "description": "Deterministic Ed25519 public keys used across the six fixtures. Seeds follow the fixtures/keys/ convention (32-byte tail). Seeds themselves are NOT reproduced here; verifier only needs the public halves.",
+  "keys": {
+    "aps_issuer": {
+      "pubkey": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+      "did": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c"
+    },
+    "org_a": {
+      "pubkey": "7422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe2674",
+      "did": "did:aps:7422b9887598068e32c4448a949adb29"
+    },
+    "org_b": {
+      "pubkey": "f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b",
+      "did": "did:aps:f381626e41e7027ea431bfe3009e94bd"
+    },
+    "subject_agent": {
+      "pubkey": "fd50b8e3b144ea244fbf7737f550bc8dd0c2650bbc1aada833ca17ff8dbf329b",
+      "did": "did:aps:fd50b8e3b144ea244fbf7737f550bc8d"
+    },
+    "delegate_1": {
+      "pubkey": "fde4fba030ad002f7c2f7d4c331f49d13fb0ec747eceebec634f1ff4cbca9def",
+      "did": "did:aps:fde4fba030ad002f7c2f7d4c331f49d1"
+    },
+    "delegate_2": {
+      "pubkey": "b4c92afb3ba57f3ab959ffe6d319c98484a2155a0f4c65b2c37011ffd197b075",
+      "did": "did:aps:b4c92afb3ba57f3ab959ffe6d319c984"
+    }
+  }
+}

--- a/a2a-trust-header/drift-explicit-flag.json
+++ b/a2a-trust-header/drift-explicit-flag.json
@@ -1,0 +1,68 @@
+{
+  "fixture": "drift-explicit-flag",
+  "description": "Drift case: two attestations over the same delegation chain, but the second advertises the chain root under a non-standard hash algorithm (keccak256 instead of sha256). Per MoltyCel agreement, this non-canonical shape MUST carry format_variant=true at the fixture level. The signatures both verify; the verifier should flag the root-format drift and refuse to treat att2 as interoperable with the sha256 baseline.",
+  "expected_verifier_output": "invalid",
+  "format_variant": true,
+  "format_variant_reason": "delegation_chain_root hash algorithm changes sha256 → keccak256 between attestations",
+  "spec_refs": [
+    "a2aproject/A2A#1742"
+  ],
+  "header_name": "x-agent-trust",
+  "header_value": {
+    "trust_header_version": "0.1",
+    "subject_agent": "did:aps:fd50b8e3b144ea244fbf7737f550bc8d",
+    "delegation_chain": [
+      {
+        "delegated_by": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+        "delegated_to": "fd50b8e3b144ea244fbf7737f550bc8dd0c2650bbc1aada833ca17ff8dbf329b",
+        "scope": [
+          "tool:read"
+        ],
+        "issued_at": "2026-04-18T12:00:00Z",
+        "expires_at": "2026-04-18T12:15:00Z",
+        "signature": {
+          "alg": "EdDSA",
+          "kid": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "pubkey": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+          "sig": "d8d74d739c3239d8e9a970fdce64a149a6390597b624676c152b7f868a8324adb875360bb6183453f6d8171959b121c122651700ddf30c340607a3f1ce2ce40b"
+        }
+      }
+    ],
+    "delegation_chain_root": "sha256:b48cfebe140183bae7e4414bff233b3c99f1f748fec3e5321fa0c49e155f3488",
+    "attestations": [
+      {
+        "payload": {
+          "agent_id": "did:aps:fd50b8e3b144ea244fbf7737f550bc8d",
+          "trust_level": "trusted",
+          "delegation_chain_root": "sha256:b48cfebe140183bae7e4414bff233b3c99f1f748fec3e5321fa0c49e155f3488",
+          "issued_at": "2026-04-18T12:00:00Z",
+          "issuer": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c"
+        },
+        "signature": {
+          "alg": "EdDSA",
+          "kid": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "pubkey": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+          "canonicalization": "RFC8785-JCS",
+          "sig": "9fb5865357b848dcc131f2b9042e920d1192cac926420e68eb5d7e3682cb1ce22f437cf18d735a3416751a034e4cf712ad4595827162a9d024fcfe2071b24009"
+        }
+      },
+      {
+        "payload": {
+          "agent_id": "did:aps:fd50b8e3b144ea244fbf7737f550bc8d",
+          "trust_level": "trusted",
+          "delegation_chain_root": "keccak256:b48cfebe140183bae7e4414bff233b3c99f1f748fec3e5321fa0c49e155f3488",
+          "issued_at": "2026-04-18T12:05:00Z",
+          "issuer": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "format_variant_note": "delegation_chain_root hash algorithm diverges from sha256 baseline"
+        },
+        "signature": {
+          "alg": "EdDSA",
+          "kid": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "pubkey": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+          "canonicalization": "RFC8785-JCS",
+          "sig": "f36f612b2e2e4a7c7669fedda79b9750a38229b37de7a17d98337f7493c7102e3698bfa8fb779933d7e13d96c93b810cc790aa573a9282d386f374e0747fd807"
+        }
+      }
+    ]
+  }
+}

--- a/a2a-trust-header/generate.ts
+++ b/a2a-trust-header/generate.ts
@@ -1,0 +1,552 @@
+/**
+ * APS Week 2 fixture generator for a2aproject/A2A#1742 x-agent-trust header.
+ *
+ * Produces 6 Ed25519-signed, JCS-canonical fixtures covering:
+ *   happy-path, trust-level ascending/descending, drift, revocation, shared-card.
+ *
+ * Run: npx tsx a2a-trust-header/generate.ts
+ *
+ * All signatures use deterministic seeds so the fixtures are byte-reproducible
+ * across machines. Seeds used:
+ *   APS issuer   : 0x00...01  (matches fixtures/keys/ test seed)
+ *   orgA issuer  : 0x00...02
+ *   orgB issuer  : 0x00...03
+ *   subject agent: 0x00...04
+ *   delegate #1  : 0x00...05
+ *   delegate #2  : 0x00...06
+ */
+
+import { writeFileSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+import {
+  publicKeyFromPrivate,
+  sign,
+  canonicalizeJCS,
+} from '/Users/tima/agent-passport-system/src/index.js'
+
+// ── Deterministic seeds ────────────────────────────────────────────────
+const seed = (tail: string) =>
+  '0'.repeat(64 - tail.length) + tail
+
+const APS_ISSUER_SEED   = seed('01')
+const ORG_A_SEED        = seed('02')
+const ORG_B_SEED        = seed('03')
+const SUBJECT_AGENT_SEED = seed('04')
+const DELEGATE_1_SEED   = seed('05')
+const DELEGATE_2_SEED   = seed('06')
+
+const APS_ISSUER_PUB    = publicKeyFromPrivate(APS_ISSUER_SEED)
+const ORG_A_PUB         = publicKeyFromPrivate(ORG_A_SEED)
+const ORG_B_PUB         = publicKeyFromPrivate(ORG_B_SEED)
+const SUBJECT_AGENT_PUB = publicKeyFromPrivate(SUBJECT_AGENT_SEED)
+const DELEGATE_1_PUB    = publicKeyFromPrivate(DELEGATE_1_SEED)
+const DELEGATE_2_PUB    = publicKeyFromPrivate(DELEGATE_2_SEED)
+
+// ── Fixed timestamps for reproducibility ───────────────────────────────
+const T0 = '2026-04-18T12:00:00Z'
+const T1 = '2026-04-18T12:05:00Z'
+const T2 = '2026-04-18T12:10:00Z'
+const T3 = '2026-04-18T12:15:00Z'
+
+const sha256 = (s: string) => createHash('sha256').update(s).digest('hex')
+
+function did(pubHex: string): string {
+  return `did:aps:${pubHex.slice(0, 32)}`
+}
+
+// Compute chain root = sha256 over JCS(chain array)
+function chainRoot(chain: unknown[]): string {
+  return `sha256:${sha256(canonicalizeJCS(chain))}`
+}
+
+interface AttestationInput {
+  trust_level: 'unknown' | 'developing' | 'trusted' | 'flagged' | 'revoked'
+  issued_at: string
+  delegation_chain_root: string
+  issuer_seed: string
+  issuer_pub: string
+  subject_agent: string
+  extra?: Record<string, unknown>
+}
+
+function signAttestation(a: AttestationInput) {
+  const payload: Record<string, unknown> = {
+    agent_id: a.subject_agent,
+    trust_level: a.trust_level,
+    delegation_chain_root: a.delegation_chain_root,
+    issued_at: a.issued_at,
+    issuer: did(a.issuer_pub),
+    ...(a.extra ?? {}),
+  }
+  const canonical = canonicalizeJCS(payload)
+  const sig = sign(canonical, a.issuer_seed)
+  return {
+    payload,
+    signature: {
+      alg: 'EdDSA',
+      kid: did(a.issuer_pub),
+      pubkey: a.issuer_pub,
+      canonicalization: 'RFC8785-JCS',
+      sig,
+    },
+  }
+}
+
+// A delegation link: principal → delegate, scope, signed by principal.
+function signDelegationLink(opts: {
+  by_seed: string
+  by_pub: string
+  to_pub: string
+  scope: string[]
+  issued_at: string
+  expires_at: string
+  spend_limit?: number
+  status?: 'active' | 'revoked'
+  revoked_at?: string
+}) {
+  const payload: Record<string, unknown> = {
+    delegated_by: opts.by_pub,
+    delegated_to: opts.to_pub,
+    scope: opts.scope,
+    issued_at: opts.issued_at,
+    expires_at: opts.expires_at,
+    ...(opts.spend_limit !== undefined ? { spend_limit: opts.spend_limit } : {}),
+    ...(opts.status ? { status: opts.status } : {}),
+    ...(opts.revoked_at ? { revoked_at: opts.revoked_at } : {}),
+  }
+  const canonical = canonicalizeJCS(payload)
+  const sig = sign(canonical, opts.by_seed)
+  return {
+    ...payload,
+    signature: {
+      alg: 'EdDSA',
+      kid: did(opts.by_pub),
+      pubkey: opts.by_pub,
+      sig,
+    },
+  }
+}
+
+function writeFixture(name: string, fixture: unknown) {
+  const path = `/Users/tima/agent-governance-testvectors/a2a-trust-header/${name}.json`
+  writeFileSync(path, JSON.stringify(fixture, null, 2) + '\n')
+  console.log(`  wrote ${name}.json`)
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// 1. happy-path.json
+// ═════════════════════════════════════════════════════════════════════
+
+{
+  const chain = [
+    signDelegationLink({
+      by_seed: APS_ISSUER_SEED,
+      by_pub: APS_ISSUER_PUB,
+      to_pub: DELEGATE_1_PUB,
+      scope: ['tool:read', 'tool:write'],
+      issued_at: T0,
+      expires_at: T3,
+    }),
+    signDelegationLink({
+      by_seed: DELEGATE_1_SEED,
+      by_pub: DELEGATE_1_PUB,
+      to_pub: SUBJECT_AGENT_PUB,
+      scope: ['tool:read'],
+      issued_at: T0,
+      expires_at: T3,
+    }),
+  ]
+  const root = chainRoot(chain)
+  const attestation = signAttestation({
+    trust_level: 'trusted',
+    issued_at: T0,
+    delegation_chain_root: root,
+    issuer_seed: APS_ISSUER_SEED,
+    issuer_pub: APS_ISSUER_PUB,
+    subject_agent: did(SUBJECT_AGENT_PUB),
+    extra: {
+      evidence_tier: 'infrastructure',
+      monotonic_narrowing: true,
+    },
+  })
+  writeFixture('happy-path', {
+    fixture: 'happy-path',
+    description:
+      'Full two-step delegation chain with monotonic scope narrowing, signed by APS issuer. ' +
+      'trust_level=trusted, delegation_chain_root in canonical sha256:<hex> form. ' +
+      'Reference case for the x-agent-trust header baseline.',
+    expected_verifier_output: 'valid',
+    format_variant: false,
+    spec_refs: ['a2aproject/A2A#1742', 'a2aproject/A2A#1628'],
+    header_name: 'x-agent-trust',
+    header_value: {
+      trust_header_version: '0.1',
+      subject_agent: did(SUBJECT_AGENT_PUB),
+      delegation_chain: chain,
+      delegation_chain_root: root,
+      attestations: [attestation],
+    },
+  })
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// 2. trust-level-ascending.json — unknown → developing → trusted
+// ═════════════════════════════════════════════════════════════════════
+
+{
+  const chain = [
+    signDelegationLink({
+      by_seed: APS_ISSUER_SEED,
+      by_pub: APS_ISSUER_PUB,
+      to_pub: SUBJECT_AGENT_PUB,
+      scope: ['tool:read'],
+      issued_at: T0,
+      expires_at: T3,
+    }),
+  ]
+  const root = chainRoot(chain)
+  const levels: Array<'unknown' | 'developing' | 'trusted'> = [
+    'unknown',
+    'developing',
+    'trusted',
+  ]
+  const times = [T0, T1, T2]
+  const attestations = levels.map((lvl, i) =>
+    signAttestation({
+      trust_level: lvl,
+      issued_at: times[i],
+      delegation_chain_root: root,
+      issuer_seed: APS_ISSUER_SEED,
+      issuer_pub: APS_ISSUER_PUB,
+      subject_agent: did(SUBJECT_AGENT_PUB),
+      extra: { sequence: i, evidence_tier: i === 0 ? 'self-declared' : i === 1 ? 'behavioral' : 'infrastructure' },
+    }),
+  )
+  writeFixture('trust-level-ascending', {
+    fixture: 'trust-level-ascending',
+    description:
+      'Trajectory of three attestations on the same subject agent, rising trust_level ' +
+      '(unknown → developing → trusted) as evidence tier strengthens. ' +
+      'Each attestation is independently signed and JCS-canonical. All over the same ' +
+      'delegation_chain_root (sha256 form). Verifier should accept all three signatures ' +
+      'and surface the monotone upward trajectory.',
+    expected_verifier_output: 'valid',
+    format_variant: false,
+    trust_level_trajectory: levels,
+    spec_refs: ['a2aproject/A2A#1742'],
+    header_name: 'x-agent-trust',
+    header_value: {
+      trust_header_version: '0.1',
+      subject_agent: did(SUBJECT_AGENT_PUB),
+      delegation_chain: chain,
+      delegation_chain_root: root,
+      attestations,
+    },
+  })
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// 3. trust-level-descending.json — trusted → developing → flagged
+// ═════════════════════════════════════════════════════════════════════
+
+{
+  const chain = [
+    signDelegationLink({
+      by_seed: APS_ISSUER_SEED,
+      by_pub: APS_ISSUER_PUB,
+      to_pub: SUBJECT_AGENT_PUB,
+      scope: ['tool:read', 'tool:write'],
+      issued_at: T0,
+      expires_at: T3,
+    }),
+  ]
+  const root = chainRoot(chain)
+  const levels: Array<'trusted' | 'developing' | 'flagged'> = [
+    'trusted',
+    'developing',
+    'flagged',
+  ]
+  const times = [T0, T1, T2]
+  const reasons: Array<string | null> = [
+    null,
+    'behavioral_drift_observed',
+    'policy_violation_confirmed',
+  ]
+  const attestations = levels.map((lvl, i) =>
+    signAttestation({
+      trust_level: lvl,
+      issued_at: times[i],
+      delegation_chain_root: root,
+      issuer_seed: APS_ISSUER_SEED,
+      issuer_pub: APS_ISSUER_PUB,
+      subject_agent: did(SUBJECT_AGENT_PUB),
+      extra: {
+        sequence: i,
+        ...(reasons[i] ? { reason: reasons[i] } : {}),
+      },
+    }),
+  )
+  writeFixture('trust-level-descending', {
+    fixture: 'trust-level-descending',
+    description:
+      'Reputation-decay trajectory: trusted → developing → flagged across three attestations. ' +
+      'All signatures verify; the final attestation carries reason=policy_violation_confirmed. ' +
+      'Verifier should accept signatures (output=valid) and surface the descending trajectory ' +
+      'so downstream policy can decide whether to honor the most recent trust_level.',
+    expected_verifier_output: 'valid',
+    format_variant: false,
+    trust_level_trajectory: levels,
+    spec_refs: ['a2aproject/A2A#1742'],
+    header_name: 'x-agent-trust',
+    header_value: {
+      trust_header_version: '0.1',
+      subject_agent: did(SUBJECT_AGENT_PUB),
+      delegation_chain: chain,
+      delegation_chain_root: root,
+      attestations,
+    },
+  })
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// 4. drift-explicit-flag.json — root format changes from sha256 to keccak256
+// ═════════════════════════════════════════════════════════════════════
+
+{
+  const chain = [
+    signDelegationLink({
+      by_seed: APS_ISSUER_SEED,
+      by_pub: APS_ISSUER_PUB,
+      to_pub: SUBJECT_AGENT_PUB,
+      scope: ['tool:read'],
+      issued_at: T0,
+      expires_at: T3,
+    }),
+  ]
+  const rootSha = chainRoot(chain)
+  // Non-standard variant: same bytes, different advertised hash algorithm
+  const rootKeccak = `keccak256:${sha256(canonicalizeJCS(chain))}`
+
+  // Attestation 1 — canonical sha256 root
+  const att1 = signAttestation({
+    trust_level: 'trusted',
+    issued_at: T0,
+    delegation_chain_root: rootSha,
+    issuer_seed: APS_ISSUER_SEED,
+    issuer_pub: APS_ISSUER_PUB,
+    subject_agent: did(SUBJECT_AGENT_PUB),
+  })
+  // Attestation 2 — same chain, but root advertised as keccak256 (drift)
+  const att2 = signAttestation({
+    trust_level: 'trusted',
+    issued_at: T1,
+    delegation_chain_root: rootKeccak,
+    issuer_seed: APS_ISSUER_SEED,
+    issuer_pub: APS_ISSUER_PUB,
+    subject_agent: did(SUBJECT_AGENT_PUB),
+    extra: { format_variant_note: 'delegation_chain_root hash algorithm diverges from sha256 baseline' },
+  })
+
+  writeFixture('drift-explicit-flag', {
+    fixture: 'drift-explicit-flag',
+    description:
+      'Drift case: two attestations over the same delegation chain, but the second advertises ' +
+      'the chain root under a non-standard hash algorithm (keccak256 instead of sha256). ' +
+      'Per MoltyCel agreement, this non-canonical shape MUST carry format_variant=true at the ' +
+      'fixture level. The signatures both verify; the verifier should flag the root-format ' +
+      'drift and refuse to treat att2 as interoperable with the sha256 baseline.',
+    expected_verifier_output: 'invalid',
+    format_variant: true,
+    format_variant_reason: 'delegation_chain_root hash algorithm changes sha256 → keccak256 between attestations',
+    spec_refs: ['a2aproject/A2A#1742'],
+    header_name: 'x-agent-trust',
+    header_value: {
+      trust_header_version: '0.1',
+      subject_agent: did(SUBJECT_AGENT_PUB),
+      delegation_chain: chain,
+      delegation_chain_root: rootSha,
+      attestations: [att1, att2],
+    },
+  })
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// 5. revocation-mid-chain.json — chain revoked at step 2, deny receipt at step 3
+// ═════════════════════════════════════════════════════════════════════
+
+{
+  // Step 1 — delegation minted, valid
+  const link1 = signDelegationLink({
+    by_seed: APS_ISSUER_SEED,
+    by_pub: APS_ISSUER_PUB,
+    to_pub: DELEGATE_1_PUB,
+    scope: ['tool:read'],
+    issued_at: T0,
+    expires_at: T3,
+    status: 'active',
+  })
+  // Step 2 — principal revokes link1 at T1
+  const link1Revoked = signDelegationLink({
+    by_seed: APS_ISSUER_SEED,
+    by_pub: APS_ISSUER_PUB,
+    to_pub: DELEGATE_1_PUB,
+    scope: ['tool:read'],
+    issued_at: T0,
+    expires_at: T3,
+    status: 'revoked',
+    revoked_at: T1,
+  })
+  // Step 3 — delegate attempts to use the revoked delegation → gateway emits deny receipt
+  const denyReceiptPayload = {
+    type: 'deny_receipt',
+    subject_agent: did(DELEGATE_1_PUB),
+    attempted_at: T2,
+    attempted_scope: 'tool:read',
+    reason: 'delegation_revoked',
+    revoked_delegation: {
+      delegated_by: APS_ISSUER_PUB,
+      delegated_to: DELEGATE_1_PUB,
+      revoked_at: T1,
+    },
+  }
+  const denyReceiptCanonical = canonicalizeJCS(denyReceiptPayload)
+  const denyReceipt = {
+    payload: denyReceiptPayload,
+    signature: {
+      alg: 'EdDSA',
+      kid: did(APS_ISSUER_PUB),
+      pubkey: APS_ISSUER_PUB,
+      canonicalization: 'RFC8785-JCS',
+      sig: sign(denyReceiptCanonical, APS_ISSUER_SEED),
+    },
+  }
+
+  const chain = [link1, link1Revoked]
+  const root = chainRoot(chain)
+
+  const attestation = signAttestation({
+    trust_level: 'revoked',
+    issued_at: T2,
+    delegation_chain_root: root,
+    issuer_seed: APS_ISSUER_SEED,
+    issuer_pub: APS_ISSUER_PUB,
+    subject_agent: did(DELEGATE_1_PUB),
+    extra: {
+      revoked_at: T1,
+      deny_receipt_ref: `sha256:${sha256(denyReceiptCanonical)}`,
+    },
+  })
+
+  writeFixture('revocation-mid-chain', {
+    fixture: 'revocation-mid-chain',
+    description:
+      'Revocation case: chain is valid at step 1 (T0), revoked at step 2 (T1), use attempted at ' +
+      'step 3 (T2) produces a signed deny receipt. The chain carries both the active and the ' +
+      'revoked delegation records so a verifier can reconstruct the state transition. ' +
+      'Per MoltyCel agreement, revocation cases carry format_variant=true because the chain ' +
+      'contains a status=revoked link that deviates from the pure happy-path shape.',
+    expected_verifier_output: 'deny',
+    format_variant: true,
+    format_variant_reason: 'delegation chain includes a status=revoked link alongside the original active link',
+    revocation_timestamp: T1,
+    spec_refs: ['a2aproject/A2A#1742'],
+    header_name: 'x-agent-trust',
+    header_value: {
+      trust_header_version: '0.1',
+      subject_agent: did(DELEGATE_1_PUB),
+      delegation_chain: chain,
+      delegation_chain_root: root,
+      attestations: [attestation],
+      deny_receipt: denyReceipt,
+    },
+  })
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// 6. shared-card-crossorg.json — orgA + orgB share a trust card per A2A#1628
+// ═════════════════════════════════════════════════════════════════════
+
+{
+  const chain = [
+    signDelegationLink({
+      by_seed: APS_ISSUER_SEED,
+      by_pub: APS_ISSUER_PUB,
+      to_pub: SUBJECT_AGENT_PUB,
+      scope: ['tool:read', 'commerce:preflight'],
+      issued_at: T0,
+      expires_at: T3,
+    }),
+  ]
+  const root = chainRoot(chain)
+
+  // Two independent signals from orgA and orgB over the SAME subject agent.
+  // No self-attestation: orgA does not sign on its own behalf, it signs about the subject.
+  const signalA = signAttestation({
+    trust_level: 'trusted',
+    issued_at: T0,
+    delegation_chain_root: root,
+    issuer_seed: ORG_A_SEED,
+    issuer_pub: ORG_A_PUB,
+    subject_agent: did(SUBJECT_AGENT_PUB),
+    extra: { issuer_org: 'orgA', evidence_tier: 'infrastructure', issuer_domain: 'orga.example' },
+  })
+  const signalB = signAttestation({
+    trust_level: 'trusted',
+    issued_at: T1,
+    delegation_chain_root: root,
+    issuer_seed: ORG_B_SEED,
+    issuer_pub: ORG_B_PUB,
+    subject_agent: did(SUBJECT_AGENT_PUB),
+    extra: { issuer_org: 'orgB', evidence_tier: 'behavioral', issuer_domain: 'orgb.example' },
+  })
+
+  // A2A Agent Card v2 — trust.signals[] per #1628
+  const agentCard = {
+    name: 'subject-agent',
+    agent_id: did(SUBJECT_AGENT_PUB),
+    pubkey: SUBJECT_AGENT_PUB,
+    trust: {
+      signals: [signalA, signalB],
+    },
+  }
+
+  writeFixture('shared-card-crossorg', {
+    fixture: 'shared-card-crossorg',
+    description:
+      'A2A Agent Card (per #1628) carrying trust.signals[] from two independent orgs (orgA + orgB) ' +
+      'about the same subject agent. Each signal is independently Ed25519-signed by its org key. ' +
+      'Neither signal is self-attested: the issuer of each signal is distinct from the subject ' +
+      'agent. Verifier should accept both signatures and surface that the subject has two ' +
+      'cross-org trust signals concurring at trust_level=trusted.',
+    expected_verifier_output: 'valid',
+    format_variant: false,
+    spec_refs: ['a2aproject/A2A#1742', 'a2aproject/A2A#1628'],
+    header_name: 'x-agent-trust',
+    header_value: {
+      trust_header_version: '0.1',
+      subject_agent: did(SUBJECT_AGENT_PUB),
+      delegation_chain: chain,
+      delegation_chain_root: root,
+      agent_card: agentCard,
+    },
+  })
+}
+
+// ── Public key registry for verifier ───────────────────────────────────
+
+writeFixture('_keys', {
+  description:
+    'Deterministic Ed25519 public keys used across the six fixtures. Seeds follow the ' +
+    'fixtures/keys/ convention (32-byte tail). Seeds themselves are NOT reproduced here; ' +
+    'verifier only needs the public halves.',
+  keys: {
+    aps_issuer:    { pubkey: APS_ISSUER_PUB,    did: did(APS_ISSUER_PUB) },
+    org_a:         { pubkey: ORG_A_PUB,         did: did(ORG_A_PUB) },
+    org_b:         { pubkey: ORG_B_PUB,         did: did(ORG_B_PUB) },
+    subject_agent: { pubkey: SUBJECT_AGENT_PUB, did: did(SUBJECT_AGENT_PUB) },
+    delegate_1:    { pubkey: DELEGATE_1_PUB,    did: did(DELEGATE_1_PUB) },
+    delegate_2:    { pubkey: DELEGATE_2_PUB,    did: did(DELEGATE_2_PUB) },
+  },
+})
+
+console.log('\nAll six fixtures generated.')

--- a/a2a-trust-header/happy-path.json
+++ b/a2a-trust-header/happy-path.json
@@ -1,0 +1,69 @@
+{
+  "fixture": "happy-path",
+  "description": "Full two-step delegation chain with monotonic scope narrowing, signed by APS issuer. trust_level=trusted, delegation_chain_root in canonical sha256:<hex> form. Reference case for the x-agent-trust header baseline.",
+  "expected_verifier_output": "valid",
+  "format_variant": false,
+  "spec_refs": [
+    "a2aproject/A2A#1742",
+    "a2aproject/A2A#1628"
+  ],
+  "header_name": "x-agent-trust",
+  "header_value": {
+    "trust_header_version": "0.1",
+    "subject_agent": "did:aps:fd50b8e3b144ea244fbf7737f550bc8d",
+    "delegation_chain": [
+      {
+        "delegated_by": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+        "delegated_to": "fde4fba030ad002f7c2f7d4c331f49d13fb0ec747eceebec634f1ff4cbca9def",
+        "scope": [
+          "tool:read",
+          "tool:write"
+        ],
+        "issued_at": "2026-04-18T12:00:00Z",
+        "expires_at": "2026-04-18T12:15:00Z",
+        "signature": {
+          "alg": "EdDSA",
+          "kid": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "pubkey": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+          "sig": "16884563550fa4c95257f662415a5f360055941521cef7cba793afafa47aa1f01c37a1ef289aaa99f0f8a74ae6c96e2f0c9642f3ba78257a39a92c728b818202"
+        }
+      },
+      {
+        "delegated_by": "fde4fba030ad002f7c2f7d4c331f49d13fb0ec747eceebec634f1ff4cbca9def",
+        "delegated_to": "fd50b8e3b144ea244fbf7737f550bc8dd0c2650bbc1aada833ca17ff8dbf329b",
+        "scope": [
+          "tool:read"
+        ],
+        "issued_at": "2026-04-18T12:00:00Z",
+        "expires_at": "2026-04-18T12:15:00Z",
+        "signature": {
+          "alg": "EdDSA",
+          "kid": "did:aps:fde4fba030ad002f7c2f7d4c331f49d1",
+          "pubkey": "fde4fba030ad002f7c2f7d4c331f49d13fb0ec747eceebec634f1ff4cbca9def",
+          "sig": "164c68c579afe299e263921237fadbd9fd7d6a765b3dc16818a081fefcaf2f3b42ddcc84baec137c13fb13084f1350c9d0c3181358144886dcd1316c514e6908"
+        }
+      }
+    ],
+    "delegation_chain_root": "sha256:e1caf9662de1564c347e1351a486cfbe5459a8475310004d751d899dc43fc529",
+    "attestations": [
+      {
+        "payload": {
+          "agent_id": "did:aps:fd50b8e3b144ea244fbf7737f550bc8d",
+          "trust_level": "trusted",
+          "delegation_chain_root": "sha256:e1caf9662de1564c347e1351a486cfbe5459a8475310004d751d899dc43fc529",
+          "issued_at": "2026-04-18T12:00:00Z",
+          "issuer": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "evidence_tier": "infrastructure",
+          "monotonic_narrowing": true
+        },
+        "signature": {
+          "alg": "EdDSA",
+          "kid": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "pubkey": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+          "canonicalization": "RFC8785-JCS",
+          "sig": "cbfa70d4e42b379bdd59b4d573d86a5cc4d3c06f577ef3867586881bca90be0cb88dd454722c4ecd7d62f653d522e9cb52162ba97686be1350e05a6b7455590e"
+        }
+      }
+    ]
+  }
+}

--- a/a2a-trust-header/revocation-mid-chain.json
+++ b/a2a-trust-header/revocation-mid-chain.json
@@ -1,0 +1,93 @@
+{
+  "fixture": "revocation-mid-chain",
+  "description": "Revocation case: chain is valid at step 1 (T0), revoked at step 2 (T1), use attempted at step 3 (T2) produces a signed deny receipt. The chain carries both the active and the revoked delegation records so a verifier can reconstruct the state transition. Per MoltyCel agreement, revocation cases carry format_variant=true because the chain contains a status=revoked link that deviates from the pure happy-path shape.",
+  "expected_verifier_output": "deny",
+  "format_variant": true,
+  "format_variant_reason": "delegation chain includes a status=revoked link alongside the original active link",
+  "revocation_timestamp": "2026-04-18T12:05:00Z",
+  "spec_refs": [
+    "a2aproject/A2A#1742"
+  ],
+  "header_name": "x-agent-trust",
+  "header_value": {
+    "trust_header_version": "0.1",
+    "subject_agent": "did:aps:fde4fba030ad002f7c2f7d4c331f49d1",
+    "delegation_chain": [
+      {
+        "delegated_by": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+        "delegated_to": "fde4fba030ad002f7c2f7d4c331f49d13fb0ec747eceebec634f1ff4cbca9def",
+        "scope": [
+          "tool:read"
+        ],
+        "issued_at": "2026-04-18T12:00:00Z",
+        "expires_at": "2026-04-18T12:15:00Z",
+        "status": "active",
+        "signature": {
+          "alg": "EdDSA",
+          "kid": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "pubkey": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+          "sig": "9c165e4270a80b1d51a4b9f677b023ce02bd12f3bdd7488c3e6603aac2e66da6bd18eedde587413c66a1992c77b01f9a34964cd386ce313196de67b2bb658603"
+        }
+      },
+      {
+        "delegated_by": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+        "delegated_to": "fde4fba030ad002f7c2f7d4c331f49d13fb0ec747eceebec634f1ff4cbca9def",
+        "scope": [
+          "tool:read"
+        ],
+        "issued_at": "2026-04-18T12:00:00Z",
+        "expires_at": "2026-04-18T12:15:00Z",
+        "status": "revoked",
+        "revoked_at": "2026-04-18T12:05:00Z",
+        "signature": {
+          "alg": "EdDSA",
+          "kid": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "pubkey": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+          "sig": "b71f0d29be56a3c87870c57a4619fc8716388c6e2c04ab9b9d56022b0e6c3baec4109cede719d7f5ee82530d3b62f23644266d543364783fc27eecb499d8cf0d"
+        }
+      }
+    ],
+    "delegation_chain_root": "sha256:dc95fa72367f07037931ba3e2a7daa153774a377215c5381e36e79d65c555064",
+    "attestations": [
+      {
+        "payload": {
+          "agent_id": "did:aps:fde4fba030ad002f7c2f7d4c331f49d1",
+          "trust_level": "revoked",
+          "delegation_chain_root": "sha256:dc95fa72367f07037931ba3e2a7daa153774a377215c5381e36e79d65c555064",
+          "issued_at": "2026-04-18T12:10:00Z",
+          "issuer": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "revoked_at": "2026-04-18T12:05:00Z",
+          "deny_receipt_ref": "sha256:632668c71fc0ecb8bc84821cbcd12b816aef7faa95958d6d0544ef3b0bcdfdd5"
+        },
+        "signature": {
+          "alg": "EdDSA",
+          "kid": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "pubkey": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+          "canonicalization": "RFC8785-JCS",
+          "sig": "1d9eed96b5171840b20ca989ff803981fcf186e0f92b7d1c14cb14a47818a60e7fda40df1f77c88d717f02b4bf307efee6bb7c0b01522e94ebf448c19f78c404"
+        }
+      }
+    ],
+    "deny_receipt": {
+      "payload": {
+        "type": "deny_receipt",
+        "subject_agent": "did:aps:fde4fba030ad002f7c2f7d4c331f49d1",
+        "attempted_at": "2026-04-18T12:10:00Z",
+        "attempted_scope": "tool:read",
+        "reason": "delegation_revoked",
+        "revoked_delegation": {
+          "delegated_by": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+          "delegated_to": "fde4fba030ad002f7c2f7d4c331f49d13fb0ec747eceebec634f1ff4cbca9def",
+          "revoked_at": "2026-04-18T12:05:00Z"
+        }
+      },
+      "signature": {
+        "alg": "EdDSA",
+        "kid": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+        "pubkey": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+        "canonicalization": "RFC8785-JCS",
+        "sig": "e48d62442988ceae9da7e2f396d504394f154a88461fd7db523395f366817955d1c9c77ee6ba51347cf58a860f8e7ab73e498e5187070027e15c1c819c2b2001"
+      }
+    }
+  }
+}

--- a/a2a-trust-header/shared-card-crossorg.json
+++ b/a2a-trust-header/shared-card-crossorg.json
@@ -1,0 +1,81 @@
+{
+  "fixture": "shared-card-crossorg",
+  "description": "A2A Agent Card (per #1628) carrying trust.signals[] from two independent orgs (orgA + orgB) about the same subject agent. Each signal is independently Ed25519-signed by its org key. Neither signal is self-attested: the issuer of each signal is distinct from the subject agent. Verifier should accept both signatures and surface that the subject has two cross-org trust signals concurring at trust_level=trusted.",
+  "expected_verifier_output": "valid",
+  "format_variant": false,
+  "spec_refs": [
+    "a2aproject/A2A#1742",
+    "a2aproject/A2A#1628"
+  ],
+  "header_name": "x-agent-trust",
+  "header_value": {
+    "trust_header_version": "0.1",
+    "subject_agent": "did:aps:fd50b8e3b144ea244fbf7737f550bc8d",
+    "delegation_chain": [
+      {
+        "delegated_by": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+        "delegated_to": "fd50b8e3b144ea244fbf7737f550bc8dd0c2650bbc1aada833ca17ff8dbf329b",
+        "scope": [
+          "tool:read",
+          "commerce:preflight"
+        ],
+        "issued_at": "2026-04-18T12:00:00Z",
+        "expires_at": "2026-04-18T12:15:00Z",
+        "signature": {
+          "alg": "EdDSA",
+          "kid": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "pubkey": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+          "sig": "73d739921a2e77bb238df89997a247fea9313ab0ac794378107c60f7565fd5b9d5b11e37e483b1397c731afe33c04b38a03ee045636be487a60bd02dd82b9307"
+        }
+      }
+    ],
+    "delegation_chain_root": "sha256:d68ae3c95a76c23f5a7d28c8fe3912f871db08d0a434dcbb08278752e15d7c1a",
+    "agent_card": {
+      "name": "subject-agent",
+      "agent_id": "did:aps:fd50b8e3b144ea244fbf7737f550bc8d",
+      "pubkey": "fd50b8e3b144ea244fbf7737f550bc8dd0c2650bbc1aada833ca17ff8dbf329b",
+      "trust": {
+        "signals": [
+          {
+            "payload": {
+              "agent_id": "did:aps:fd50b8e3b144ea244fbf7737f550bc8d",
+              "trust_level": "trusted",
+              "delegation_chain_root": "sha256:d68ae3c95a76c23f5a7d28c8fe3912f871db08d0a434dcbb08278752e15d7c1a",
+              "issued_at": "2026-04-18T12:00:00Z",
+              "issuer": "did:aps:7422b9887598068e32c4448a949adb29",
+              "issuer_org": "orgA",
+              "evidence_tier": "infrastructure",
+              "issuer_domain": "orga.example"
+            },
+            "signature": {
+              "alg": "EdDSA",
+              "kid": "did:aps:7422b9887598068e32c4448a949adb29",
+              "pubkey": "7422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe2674",
+              "canonicalization": "RFC8785-JCS",
+              "sig": "ddcb205370abf5a4bd1739ec0050fe07ead0e2a262d0431588dbdfd01e8e814bc1ad4d1e1355899ad7c426a32f4f98433af488454f6adf391c9721300c233707"
+            }
+          },
+          {
+            "payload": {
+              "agent_id": "did:aps:fd50b8e3b144ea244fbf7737f550bc8d",
+              "trust_level": "trusted",
+              "delegation_chain_root": "sha256:d68ae3c95a76c23f5a7d28c8fe3912f871db08d0a434dcbb08278752e15d7c1a",
+              "issued_at": "2026-04-18T12:05:00Z",
+              "issuer": "did:aps:f381626e41e7027ea431bfe3009e94bd",
+              "issuer_org": "orgB",
+              "evidence_tier": "behavioral",
+              "issuer_domain": "orgb.example"
+            },
+            "signature": {
+              "alg": "EdDSA",
+              "kid": "did:aps:f381626e41e7027ea431bfe3009e94bd",
+              "pubkey": "f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b",
+              "canonicalization": "RFC8785-JCS",
+              "sig": "5aa85f41e2a9d7d8795ca240f6b9947d568f5dd0b51ea90e43868cdfa154a3c313f146f0759e4206251b54ebb56fe37dd0bf7afc77fafd3380a2cea26f89f20b"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/a2a-trust-header/trust-level-ascending.json
+++ b/a2a-trust-header/trust-level-ascending.json
@@ -1,0 +1,93 @@
+{
+  "fixture": "trust-level-ascending",
+  "description": "Trajectory of three attestations on the same subject agent, rising trust_level (unknown → developing → trusted) as evidence tier strengthens. Each attestation is independently signed and JCS-canonical. All over the same delegation_chain_root (sha256 form). Verifier should accept all three signatures and surface the monotone upward trajectory.",
+  "expected_verifier_output": "valid",
+  "format_variant": false,
+  "trust_level_trajectory": [
+    "unknown",
+    "developing",
+    "trusted"
+  ],
+  "spec_refs": [
+    "a2aproject/A2A#1742"
+  ],
+  "header_name": "x-agent-trust",
+  "header_value": {
+    "trust_header_version": "0.1",
+    "subject_agent": "did:aps:fd50b8e3b144ea244fbf7737f550bc8d",
+    "delegation_chain": [
+      {
+        "delegated_by": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+        "delegated_to": "fd50b8e3b144ea244fbf7737f550bc8dd0c2650bbc1aada833ca17ff8dbf329b",
+        "scope": [
+          "tool:read"
+        ],
+        "issued_at": "2026-04-18T12:00:00Z",
+        "expires_at": "2026-04-18T12:15:00Z",
+        "signature": {
+          "alg": "EdDSA",
+          "kid": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "pubkey": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+          "sig": "d8d74d739c3239d8e9a970fdce64a149a6390597b624676c152b7f868a8324adb875360bb6183453f6d8171959b121c122651700ddf30c340607a3f1ce2ce40b"
+        }
+      }
+    ],
+    "delegation_chain_root": "sha256:b48cfebe140183bae7e4414bff233b3c99f1f748fec3e5321fa0c49e155f3488",
+    "attestations": [
+      {
+        "payload": {
+          "agent_id": "did:aps:fd50b8e3b144ea244fbf7737f550bc8d",
+          "trust_level": "unknown",
+          "delegation_chain_root": "sha256:b48cfebe140183bae7e4414bff233b3c99f1f748fec3e5321fa0c49e155f3488",
+          "issued_at": "2026-04-18T12:00:00Z",
+          "issuer": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "sequence": 0,
+          "evidence_tier": "self-declared"
+        },
+        "signature": {
+          "alg": "EdDSA",
+          "kid": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "pubkey": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+          "canonicalization": "RFC8785-JCS",
+          "sig": "f8768ca4a034347b308fa71e93d6198955857875031b49f131266a2f033ed3e377f2d6ce3be6c099c7ba34ebea7b6df005f81f57adb0e6a2349725e343a72f02"
+        }
+      },
+      {
+        "payload": {
+          "agent_id": "did:aps:fd50b8e3b144ea244fbf7737f550bc8d",
+          "trust_level": "developing",
+          "delegation_chain_root": "sha256:b48cfebe140183bae7e4414bff233b3c99f1f748fec3e5321fa0c49e155f3488",
+          "issued_at": "2026-04-18T12:05:00Z",
+          "issuer": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "sequence": 1,
+          "evidence_tier": "behavioral"
+        },
+        "signature": {
+          "alg": "EdDSA",
+          "kid": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "pubkey": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+          "canonicalization": "RFC8785-JCS",
+          "sig": "b148bc3b72552d7631910c37206138d02a04523e401b3cb3c3f73e6d11bf1a82052ada77023405db2d1324a184f2f5e5ecc28e05f02a4fda6dc6c62cef33bd0a"
+        }
+      },
+      {
+        "payload": {
+          "agent_id": "did:aps:fd50b8e3b144ea244fbf7737f550bc8d",
+          "trust_level": "trusted",
+          "delegation_chain_root": "sha256:b48cfebe140183bae7e4414bff233b3c99f1f748fec3e5321fa0c49e155f3488",
+          "issued_at": "2026-04-18T12:10:00Z",
+          "issuer": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "sequence": 2,
+          "evidence_tier": "infrastructure"
+        },
+        "signature": {
+          "alg": "EdDSA",
+          "kid": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "pubkey": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+          "canonicalization": "RFC8785-JCS",
+          "sig": "b433a1c9490599db75b040be632ba4e81ce4b85f4036c617efbcdef1dc865b32a86e4c19009e6bf508a1ea83fc06a3c4cbe156ec02505f67df6b5c33e6366c07"
+        }
+      }
+    ]
+  }
+}

--- a/a2a-trust-header/trust-level-descending.json
+++ b/a2a-trust-header/trust-level-descending.json
@@ -1,0 +1,93 @@
+{
+  "fixture": "trust-level-descending",
+  "description": "Reputation-decay trajectory: trusted → developing → flagged across three attestations. All signatures verify; the final attestation carries reason=policy_violation_confirmed. Verifier should accept signatures (output=valid) and surface the descending trajectory so downstream policy can decide whether to honor the most recent trust_level.",
+  "expected_verifier_output": "valid",
+  "format_variant": false,
+  "trust_level_trajectory": [
+    "trusted",
+    "developing",
+    "flagged"
+  ],
+  "spec_refs": [
+    "a2aproject/A2A#1742"
+  ],
+  "header_name": "x-agent-trust",
+  "header_value": {
+    "trust_header_version": "0.1",
+    "subject_agent": "did:aps:fd50b8e3b144ea244fbf7737f550bc8d",
+    "delegation_chain": [
+      {
+        "delegated_by": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+        "delegated_to": "fd50b8e3b144ea244fbf7737f550bc8dd0c2650bbc1aada833ca17ff8dbf329b",
+        "scope": [
+          "tool:read",
+          "tool:write"
+        ],
+        "issued_at": "2026-04-18T12:00:00Z",
+        "expires_at": "2026-04-18T12:15:00Z",
+        "signature": {
+          "alg": "EdDSA",
+          "kid": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "pubkey": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+          "sig": "cf9ede70b534e1842e332d003c1c092112caed64c365c4228d1f25eb393e1aee83584cf1ede95c598d66c7c009c92b4993aca642097253a48e7f4e4a1656e107"
+        }
+      }
+    ],
+    "delegation_chain_root": "sha256:5bf1b99e65970d025b5dfbeda762b0b6c8f03274b42a3eabf59237d634490a70",
+    "attestations": [
+      {
+        "payload": {
+          "agent_id": "did:aps:fd50b8e3b144ea244fbf7737f550bc8d",
+          "trust_level": "trusted",
+          "delegation_chain_root": "sha256:5bf1b99e65970d025b5dfbeda762b0b6c8f03274b42a3eabf59237d634490a70",
+          "issued_at": "2026-04-18T12:00:00Z",
+          "issuer": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "sequence": 0
+        },
+        "signature": {
+          "alg": "EdDSA",
+          "kid": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "pubkey": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+          "canonicalization": "RFC8785-JCS",
+          "sig": "8ff916915f81a6f8542d395b141cddb668100f591c9f8b8da7b62c0e4b64002bf2236815d6aaaefc3305b09ad2ae9d625d346188e5c32f33b6009ce8fc49c100"
+        }
+      },
+      {
+        "payload": {
+          "agent_id": "did:aps:fd50b8e3b144ea244fbf7737f550bc8d",
+          "trust_level": "developing",
+          "delegation_chain_root": "sha256:5bf1b99e65970d025b5dfbeda762b0b6c8f03274b42a3eabf59237d634490a70",
+          "issued_at": "2026-04-18T12:05:00Z",
+          "issuer": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "sequence": 1,
+          "reason": "behavioral_drift_observed"
+        },
+        "signature": {
+          "alg": "EdDSA",
+          "kid": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "pubkey": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+          "canonicalization": "RFC8785-JCS",
+          "sig": "abed8a58331cf82bbaa3f1f0dec9bedd2d0dcb5111ebfa2c5735f087db1be0f080861e372f9a161b46c6eec3ec71df9ba03e7761d3a61c104ff21a8299085c00"
+        }
+      },
+      {
+        "payload": {
+          "agent_id": "did:aps:fd50b8e3b144ea244fbf7737f550bc8d",
+          "trust_level": "flagged",
+          "delegation_chain_root": "sha256:5bf1b99e65970d025b5dfbeda762b0b6c8f03274b42a3eabf59237d634490a70",
+          "issued_at": "2026-04-18T12:10:00Z",
+          "issuer": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "sequence": 2,
+          "reason": "policy_violation_confirmed"
+        },
+        "signature": {
+          "alg": "EdDSA",
+          "kid": "did:aps:4cb5abf6ad79fbf5abbccafcc269d85c",
+          "pubkey": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+          "canonicalization": "RFC8785-JCS",
+          "sig": "89e4cda5ba20fefe7e846235df6fec594a22217e23b676c3695776ce95faf366077448f58f4ccbdf38e7fff9e400f47cca85113bc666a434db90cf4f1e59d207"
+        }
+      }
+    ]
+  }
+}

--- a/a2a-trust-header/verify.ts
+++ b/a2a-trust-header/verify.ts
@@ -1,0 +1,170 @@
+/**
+ * APS verifier for the 6 a2a-trust-header fixtures.
+ *
+ * For each fixture:
+ *   1. Re-canonicalize every payload with RFC8785-JCS (APS canonicalizeJCS).
+ *   2. Verify every signature against its advertised pubkey.
+ *   3. Recompute delegation_chain_root and compare where applicable.
+ *   4. Inspect format_variant flag and trust_level trajectory.
+ *   5. Derive a verifier verdict (valid | invalid | deny).
+ *   6. Assert verdict == expected_verifier_output.
+ *
+ * Exit 0 = all six fixtures round-trip. Exit 1 = any divergence.
+ */
+
+import { readFileSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+import {
+  canonicalizeJCS,
+  verify,
+} from '/Users/tima/agent-passport-system/src/index.js'
+
+const DIR = '/Users/tima/agent-governance-testvectors/a2a-trust-header'
+
+const sha256 = (s: string) => createHash('sha256').update(s).digest('hex')
+
+interface Signature {
+  alg: string
+  kid: string
+  pubkey: string
+  sig: string
+  canonicalization?: string
+}
+
+function verifySigned(obj: { signature: Signature } & Record<string, unknown>, context: string): boolean {
+  const { signature, ...rest } = obj
+  // Links store the signature inline on the same object; attestations wrap
+  // { payload, signature }. Both cases canonicalize everything except `signature`.
+  const canonical = canonicalizeJCS(rest as unknown as Record<string, unknown>)
+  const ok = verify(canonical, signature.sig, signature.pubkey)
+  if (!ok) console.error(`  FAIL signature on ${context}`)
+  return ok
+}
+
+function verifyAttestation(att: { payload: Record<string, unknown>; signature: Signature }, label: string): boolean {
+  const canonical = canonicalizeJCS(att.payload)
+  const ok = verify(canonical, att.signature.sig, att.signature.pubkey)
+  if (!ok) console.error(`  FAIL signature on ${label}`)
+  return ok
+}
+
+function chainRoot(chain: unknown[]): string {
+  return `sha256:${sha256(canonicalizeJCS(chain))}`
+}
+
+interface VerifyResult {
+  verdict: 'valid' | 'invalid' | 'deny'
+  notes: string[]
+}
+
+function runFixture(name: string, fixture: Record<string, unknown>): VerifyResult {
+  const notes: string[] = []
+  const hv = fixture.header_value as Record<string, unknown>
+  const chain = (hv.delegation_chain ?? []) as Array<Record<string, unknown> & { signature: Signature }>
+  const attestations = (hv.attestations ?? []) as Array<{ payload: Record<string, unknown>; signature: Signature }>
+  const agentCard = hv.agent_card as { trust?: { signals?: typeof attestations } } | undefined
+  const denyReceipt = hv.deny_receipt as { payload: Record<string, unknown>; signature: Signature } | undefined
+
+  // 1. Verify every delegation link signature.
+  let allOk = true
+  for (let i = 0; i < chain.length; i++) {
+    const ok = verifySigned(chain[i], `${name}/chain[${i}]`)
+    allOk &&= ok
+  }
+
+  // 2. Verify every attestation signature.
+  for (let i = 0; i < attestations.length; i++) {
+    const ok = verifyAttestation(attestations[i], `${name}/attestations[${i}]`)
+    allOk &&= ok
+  }
+
+  // 3. Verify agent card signals if present (shared-card fixture).
+  if (agentCard?.trust?.signals) {
+    for (let i = 0; i < agentCard.trust.signals.length; i++) {
+      const ok = verifyAttestation(agentCard.trust.signals[i], `${name}/agent_card.trust.signals[${i}]`)
+      allOk &&= ok
+    }
+  }
+
+  // 4. Verify deny receipt signature.
+  let denyPresent = false
+  if (denyReceipt) {
+    denyPresent = true
+    const ok = verifyAttestation(denyReceipt, `${name}/deny_receipt`)
+    allOk &&= ok
+  }
+
+  // 5. Recompute chain root from chain array, compare to header_value.delegation_chain_root.
+  if (chain.length > 0 && typeof hv.delegation_chain_root === 'string') {
+    const computed = chainRoot(chain)
+    if (computed !== hv.delegation_chain_root) {
+      notes.push(`header root ${hv.delegation_chain_root} != computed ${computed}`)
+    }
+  }
+
+  // 6. Check root format consistency across attestations (drift detection).
+  const rootsSeen = new Set<string>()
+  for (const att of attestations) {
+    const r = att.payload.delegation_chain_root
+    if (typeof r === 'string') {
+      const algo = r.split(':')[0]
+      rootsSeen.add(algo)
+    }
+  }
+  const rootDrift = rootsSeen.size > 1
+
+  // 7. Check for revoked delegation status in the chain.
+  const hasRevokedLink = chain.some(link => link.status === 'revoked')
+
+  // 8. Derive verdict.
+  let verdict: 'valid' | 'invalid' | 'deny'
+  if (!allOk) {
+    verdict = 'invalid'
+    notes.push('at least one signature failed')
+  } else if (rootDrift) {
+    // Non-standard root format across attestations — interop-incompatible.
+    verdict = 'invalid'
+    notes.push(`root format drift across algorithms: ${[...rootsSeen].join(',')}`)
+  } else if (hasRevokedLink && denyPresent) {
+    verdict = 'deny'
+    notes.push('chain carries a revoked link and a signed deny receipt')
+  } else {
+    verdict = 'valid'
+  }
+
+  return { verdict, notes }
+}
+
+function main() {
+  const fixtureNames = [
+    'happy-path',
+    'trust-level-ascending',
+    'trust-level-descending',
+    'drift-explicit-flag',
+    'revocation-mid-chain',
+    'shared-card-crossorg',
+  ]
+
+  let fails = 0
+  for (const name of fixtureNames) {
+    const path = `${DIR}/${name}.json`
+    const fixture = JSON.parse(readFileSync(path, 'utf8')) as Record<string, unknown>
+    const expected = fixture.expected_verifier_output as string
+    const { verdict, notes } = runFixture(name, fixture)
+    const ok = verdict === expected
+    const status = ok ? 'PASS' : 'FAIL'
+    console.log(`[${status}] ${name}  expected=${expected}  got=${verdict}`)
+    if (notes.length) notes.forEach(n => console.log(`         · ${n}`))
+    if (!ok) fails++
+  }
+
+  if (fails === 0) {
+    console.log('\n6/6 fixtures round-trip through APS verifier.')
+    process.exit(0)
+  } else {
+    console.error(`\n${fails} fixture(s) failed.`)
+    process.exit(1)
+  }
+}
+
+main()


### PR DESCRIPTION
## Summary

APS Week 2 contribution to [a2aproject/A2A#1742](https://github.com/a2aproject/A2A/issues/1742)
— cross-verification fixtures for the `x-agent-trust` header.

Six Ed25519-signed, JCS-canonical fixtures live under the new
`a2a-trust-header/` directory. Each is a standalone JSON file with a
self-describing shape: `description`, `expected_verifier_output`,
`format_variant`, `spec_refs`, plus the signed `header_value` that
would be emitted as the `x-agent-trust` header value.

Format conventions in this PR were locked in the #1742 thread with
@MoltyCel:

- `delegation_chain_root: "sha256:<hex>"` for happy-path cases.
- Drift and revocation cases carry `format_variant: true` at the
  fixture level to explicitly flag any shape deviation.
- Fixtures exercise trust_level trajectories and the Agent Card
  `trust.signals[]` cross-org pattern from #1628.

## The six cases

| # | File | Case | `format_variant` | `expected_verifier_output` |
|---|------|------|---|---|
| 1 | `happy-path.json` | Two-step delegation chain, monotonic narrowing, single `trusted` attestation | `false` | `valid` |
| 2 | `trust-level-ascending.json` | `unknown → developing → trusted` trajectory | `false` | `valid` |
| 3 | `trust-level-descending.json` | `trusted → developing → flagged` reputation decay | `false` | `valid` |
| 4 | `drift-explicit-flag.json` | Same chain, root hash algorithm drifts `sha256 → keccak256` | **`true`** | `invalid` |
| 5 | `revocation-mid-chain.json` | Valid at T0, revoked at T1, use attempted at T2 produces signed deny receipt | **`true`** | `deny` |
| 6 | `shared-card-crossorg.json` | A2A Agent Card (per #1628) with `trust.signals[]` from orgA + orgB, no self-attestation | `false` | `valid` |

## Reproducibility

- Deterministic seeds (32-byte, right-aligned). `aps_issuer` seed
  matches the `fixtures/keys/` test key already in this repo, so the
  new fixtures share the same keypair as the existing vectors.
- Fixed ISO-8601 timestamps across T0..T3.
- `a2a-trust-header/generate.ts` regenerates every fixture byte-for-byte.
- `a2a-trust-header/verify.ts` round-trips every fixture through APS's
  own `canonicalizeJCS` + `verify` and asserts the verdict matches.
  6/6 pass locally.

```
[PASS] happy-path                expected=valid    got=valid
[PASS] trust-level-ascending     expected=valid    got=valid
[PASS] trust-level-descending    expected=valid    got=valid
[PASS] drift-explicit-flag       expected=invalid  got=invalid
[PASS] revocation-mid-chain      expected=deny     got=deny
[PASS] shared-card-crossorg      expected=valid    got=valid
```

## Scope

Touches only the new `a2a-trust-header/` directory. Does not modify
the existing `fixtures/`, `expected/`, `conformance/`, or
`implementations/` trees.

## Review

@MoltyCel @tomjwxf — format matches what we locked in #1742. Happy to
fold in revisions before other implementations start cross-verifying.

Refs:
- [a2aproject/A2A#1742](https://github.com/a2aproject/A2A/issues/1742) (primary)
- [a2aproject/A2A#1628](https://github.com/a2aproject/A2A/issues/1628) (Agent Card `trust.signals[]`)
