### PR TITLE
Add cedar-policy-gate conformance vectors (fail-closed bar from #598/#601)

### DIFF
--- a/cedar-policy-gate/1-in-on-string-rejection/README.md
+++ b/cedar-policy-gate/1-in-on-string-rejection/README.md
@@ -1,0 +1,57 @@
+# Case 1 - in-on-String rejection (the core advisory vector)
+
+## What this proves
+
+A Cedar policy gate must not let a type-erroring `forbid` rule be silently
+discarded into a permit-all. The policy here intends to block dangerous shell
+commands:
+
+```cedar
+forbid(principal, action, resource) when { context.command in ["rm", "dd", "mkfs"] };
+permit(principal, action, resource);
+```
+
+The forbid rule uses `context.command in [...]`. In Cedar, `in` is the
+entity-hierarchy membership operator (for example `principal in Group::"admins"`
+or `action in [Action::"read"]`), not string-set membership. Applied to a String
+operand it is a type error. Cedar discards the erroring policy and continues
+evaluation, so the only surviving rule is the terminal `permit`. The tool call
+`rm` is then ALLOWED.
+
+## Required decision
+
+DENY (or policy-load rejection). A conformant gate either:
+
+1. rejects this policy at load time (the `context.<attr> in [strings]` hazard is
+   detectable statically, which is what the protect-mcp CI tripwire in
+   `policy-lint.test.ts` enforces against shipped policies), or
+2. detects the per-policy evaluation error at runtime and denies (fail closed).
+
+protect-mcp 0.7.0 takes path 2 at evaluate time: `extractPolicyErrors()` finds
+the discarded policy, and the single `onEvalError()` chokepoint maps any
+per-policy error to DENY under enforcement. See
+`packages/protect-mcp/src/cedar-evaluator.ts`.
+
+## The precise failure mode a non-conformant gate exhibits
+
+It returns ALLOW for `rm`. The erroring forbid vanishes, the residual permit
+fires, and the gate reports success with no error surfaced to the caller. The
+operator believes `rm`, `dd`, and `mkfs` are blocked; they are not.
+
+## Reference invocation
+
+```sh
+printf '%s' "$(jq -r .policy input.json)" > /tmp/case1.cedar
+npx protect-mcp@0.7.0 evaluate \
+  --policy /tmp/case1.cedar \
+  --tool Bash \
+  --input "$(jq -c .input input.json)"
+# exit 2 = DENY (conformant). exit 0 = ALLOW (non-conformant: the advisory vector fired).
+```
+
+## Disclosure links
+
+- wshobson/agents issue #598 (reporter matiaszabal): Cedar `in`-on-String
+  silently discards all forbid rules; the terminal permit fires.
+- Upstream Cedar behavior: cedar-policy/cedar#2428.
+- protect-mcp 0.7.0 is the reference conformant implementation.

--- a/cedar-policy-gate/1-in-on-string-rejection/expected-output.json
+++ b/cedar-policy-gate/1-in-on-string-rejection/expected-output.json
@@ -1,0 +1,8 @@
+{
+  "decision": "DENY",
+  "allowed": false,
+  "acceptable_decisions": ["DENY", "POLICY_LOAD_REJECTED"],
+  "exit_code": 2,
+  "reason": "cedar_policy_errored: the forbid rule type-errors (`in` on a String operand) and is discarded by Cedar; a residual permit must not be allowed to stand. Any per-policy evaluation error denies under enforcement.",
+  "rationale": "This is the core advisory vector. A non-conformant gate lets Cedar silently drop the erroring forbid and returns the terminal permit as ALLOW. A conformant gate detects the per-policy error and denies (protect-mcp 0.7.0 via the onEvalError chokepoint after extractPolicyErrors), or rejects the policy at load time. Either outcome blocks the dangerous tool call."
+}

--- a/cedar-policy-gate/1-in-on-string-rejection/input.json
+++ b/cedar-policy-gate/1-in-on-string-rejection/input.json
@@ -1,0 +1,8 @@
+{
+  "tool": "Bash",
+  "policy": "forbid(principal, action, resource) when { context.command in [\"rm\", \"dd\", \"mkfs\"] };\npermit(principal, action, resource);",
+  "input": {
+    "command": "rm"
+  },
+  "note": "The forbid rule uses the hazardous `context.<attr> in [stringList]` pattern. Cedar treats `in` as entity-hierarchy membership, not string-set membership, so applying it to a String operand is a type error. Cedar silently discards the erroring forbid, leaving the terminal permit as the only surviving rule. A non-conformant gate therefore returns ALLOW for `rm`, which is the advisory vector (wshobson/agents #598, cedar-policy/cedar#2428). A conformant gate either rejects the policy at load or denies at evaluation."
+}

--- a/cedar-policy-gate/2-errored-policy-no-permit/README.md
+++ b/cedar-policy-gate/2-errored-policy-no-permit/README.md
@@ -1,0 +1,63 @@
+# Case 2 - errored policy must not let a residual permit stand
+
+## What this proves
+
+A per-policy evaluation error poisons the entire decision. Even when a separate,
+correctly typed `permit` exists and matches the input, a gate must not return
+that permit while another policy in the set errored.
+
+```cedar
+forbid(principal, action, resource) when { context.command in ["rm"] };
+permit(principal, action, resource) when { context.command == "rm" };
+```
+
+The forbid errors (the `in`-on-String type error) and is discarded. The permit is
+valid and matches `rm`. A naive engine reports ALLOW because, after the forbid is
+dropped, the permit is the matching rule.
+
+## Required decision
+
+DENY under enforcement. The decision is unsound because one of the policies could
+not be evaluated. protect-mcp 0.7.0 denies whenever `extractPolicyErrors()`
+returns a non-empty list, regardless of what the surviving rules decide. See the
+per-policy-error branch in `evaluateCedar()` in
+`packages/protect-mcp/src/cedar-evaluator.ts`.
+
+Note that this is stricter than raw Cedar authorization. Under vanilla Cedar
+semantics this request ALLOWs: the errored forbid is dropped and the valid permit
+matches. The conformance requirement here is therefore "Cedar evaluation PLUS a
+mandatory deny on any per-policy error." An engine-agnostic implementation must
+expose per-policy diagnostics (the equivalent of Cedar's `Response.diagnostics`
+errors) to detect the discarded forbid. A gate that reads only the final
+allow/deny bit from a diagnostics-blind `isAuthorized()` wrapper will return ALLOW
+and fail this case, which is exactly the hazard the bar exists to catch.
+
+## How this differs from case 1
+
+Case 1 has a bare terminal permit (permit-all) and proves the discarded forbid
+opens the gate. Case 2 has a permit that genuinely matches the input, proving the
+rule is the same even when the residual permit is not a degenerate permit-all: an
+errored sibling policy still forces a deny.
+
+## The precise failure mode a non-conformant gate exhibits
+
+It returns ALLOW because it evaluates only the rules that did not error and finds
+the matching permit, never surfacing that a sibling forbid was silently dropped.
+
+## Reference invocation
+
+```sh
+printf '%s' "$(jq -r .policy input.json)" > /tmp/case2.cedar
+npx protect-mcp@0.7.0 evaluate \
+  --policy /tmp/case2.cedar \
+  --tool Bash \
+  --input "$(jq -c .input input.json)"
+# exit 2 = DENY (conformant). exit 0 = ALLOW (non-conformant).
+```
+
+## Disclosure links
+
+- wshobson/agents issue #598: discarded forbid rules from the `in`-on-String
+  type error.
+- Upstream Cedar behavior: cedar-policy/cedar#2428.
+- protect-mcp 0.7.0 is the reference conformant implementation.

--- a/cedar-policy-gate/2-errored-policy-no-permit/expected-output.json
+++ b/cedar-policy-gate/2-errored-policy-no-permit/expected-output.json
@@ -1,0 +1,8 @@
+{
+  "decision": "DENY",
+  "allowed": false,
+  "acceptable_decisions": ["DENY", "POLICY_LOAD_REJECTED"],
+  "exit_code": 2,
+  "reason": "cedar_policy_errored: a forbid rule errored at evaluation and was discarded; the surviving permit cannot be trusted, so the decision is unsound and denies under enforcement.",
+  "rationale": "Distinct from case 1 in that a syntactically and type-valid permit really does exist and really does match the input. The point is that a per-policy error anywhere in the set poisons the whole decision: a gate must not return that residual permit. protect-mcp 0.7.0 denies because extractPolicyErrors() is non-empty, independent of what the surviving rules say."
+}

--- a/cedar-policy-gate/2-errored-policy-no-permit/input.json
+++ b/cedar-policy-gate/2-errored-policy-no-permit/input.json
@@ -1,0 +1,8 @@
+{
+  "tool": "Bash",
+  "policy": "forbid(principal, action, resource) when { context.command in [\"rm\"] };\npermit(principal, action, resource) when { context.command == \"rm\" };",
+  "input": {
+    "command": "rm"
+  },
+  "note": "One forbid rule errors at evaluation (the `in`-on-String type error) and is discarded by Cedar. A separate, validly typed permit matches `rm` and would otherwise stand alone. Under enforcement, a per-policy evaluation error must not let any residual permit be returned: the gate denies because the decision is unsound, not because a rule cleanly matched."
+}

--- a/cedar-policy-gate/3-fail-closed-engine-unavailable/README.md
+++ b/cedar-policy-gate/3-fail-closed-engine-unavailable/README.md
@@ -1,0 +1,53 @@
+# Case 3 - fail closed when the engine is unavailable
+
+## What this proves
+
+When the policy engine cannot produce a decision (it is not installed, it is
+unreachable, or evaluation throws), the gate must DENY. It must never fall back to
+ALLOW just because it could not run the policy.
+
+The policy in this case is a deliberately permissive `permit(principal, action,
+resource);`. With a working engine it would ALLOW. The test condition is the
+engine being unavailable, so the required outcome flips to DENY. This is exactly
+the property a naive gate gets wrong: it treats "could not evaluate" as "no
+applicable forbid" and permits.
+
+## Required decision
+
+DENY. protect-mcp 0.7.0 returns DENY via the `onEvalError()` chokepoint when
+`ensureCedarWasm()` resolves false (`cedar_wasm_not_available`) or when the
+`isAuthorized` call throws (`cedar_eval_error`). See
+`packages/protect-mcp/src/cedar-evaluator.ts`. Before 0.7.0 this path returned
+ALLOW; the 0.7.0 security release inverts it (see the package CHANGELOG).
+
+## How an implementation simulates engine-unavailable
+
+Pick whichever is cleanest for the implementation under test:
+
+- Run `evaluate` in an environment where the Cedar engine dependency is not
+  installed. For protect-mcp this means the optional `@cedar-policy/cedar-wasm`
+  module is absent, so `ensureCedarWasm()` returns false and the gate denies.
+- Point the gate at an engine endpoint that is down, or inject a fault that makes
+  the engine call throw.
+- Use the implementation's own self-test path: protect-mcp's
+  `runEvaluatorSelfTest()` includes an "engine unavailable denies" case that runs
+  even when the engine is absent, asserting DENY.
+
+## The precise failure mode a non-conformant gate exhibits
+
+It returns ALLOW because no `forbid` rule was evaluated (none could be), so it
+concludes nothing forbids the action. A request that should have been blocked
+proceeds with no policy actually applied.
+
+## Why this case is not driven by run.sh
+
+`run.sh` drives the mechanically-checkable cases (1, 2, 4, 5) that depend only on
+policy text and input. Case 3 requires manipulating the engine availability of
+the implementation under test, which is implementation-specific, so it is
+verified by hand per the simulation notes above.
+
+## Disclosure links
+
+- The fail-open default is the same class of defect documented for the 0.5.x and
+  0.6.x lines in the protect-mcp CHANGELOG (0.7.0 security release).
+- protect-mcp 0.7.0 is the reference conformant implementation.

--- a/cedar-policy-gate/3-fail-closed-engine-unavailable/expected-output.json
+++ b/cedar-policy-gate/3-fail-closed-engine-unavailable/expected-output.json
@@ -1,0 +1,8 @@
+{
+  "decision": "DENY",
+  "allowed": false,
+  "acceptable_decisions": ["DENY"],
+  "exit_code": 2,
+  "reason": "cedar_wasm_not_available (or cedar_eval_error): the engine could not produce a decision, so the gate fails closed and denies.",
+  "rationale": "Even though the policy is a valid permit-all, an unreachable or throwing engine means the gate cannot know what the policy says. It must deny rather than fall back to allow. protect-mcp 0.7.0 returns DENY through onEvalError() when ensureCedarWasm() is false or the isAuthorized call throws. Note this is the inverse of the naive default: a permit-all that would ALLOW with a working engine must still DENY when the engine is gone."
+}

--- a/cedar-policy-gate/3-fail-closed-engine-unavailable/input.json
+++ b/cedar-policy-gate/3-fail-closed-engine-unavailable/input.json
@@ -1,0 +1,9 @@
+{
+  "tool": "Bash",
+  "policy": "permit(principal, action, resource);",
+  "input": {
+    "command": "rm"
+  },
+  "engine_state": "unavailable",
+  "note": "The policy itself is a valid permit-all. The test condition is that the policy engine cannot be reached or evaluation throws (for example the Cedar WASM module is not installed, or the engine call raises). A gate must DENY when it cannot decide, never default to the permit. This case is checked by removing or disabling the engine, not by the policy text. See `simulate` below for how an implementation reproduces engine-unavailable."
+}

--- a/cedar-policy-gate/4-valid-forbid-denies/README.md
+++ b/cedar-policy-gate/4-valid-forbid-denies/README.md
@@ -1,0 +1,64 @@
+# Case 4 - valid forbid denies (positive control)
+
+## What this proves
+
+A correctly written `forbid` actually denies the forbidden action, and does so
+because the rule matched, not because a policy errored. This is a positive
+control: it stops a gate from passing the suite by simply denying everything that
+involves an error.
+
+```cedar
+forbid(principal, action, resource) when { ["rm", "dd", "mkfs"].contains(context.command) };
+permit(principal, action, resource);
+```
+
+This uses the correct Cedar idiom: `[set].contains(operand)` is set membership on
+a set literal and is well typed when the operand is a String. It is the
+recommended replacement for the hazardous `context.<attr> in [strings]` form. The
+forbid matches `command == "rm"` and denies cleanly. No per-policy error is
+raised.
+
+## Required decision
+
+DENY for the right reason. The rule matched and produced an authoritative deny.
+protect-mcp 0.7.0 returns a `cedar_deny` decision with an empty policy-error list,
+which is distinct from the deny-on-error path exercised by cases 1 and 2.
+
+The mechanical runner (`run.sh`) only checks the coarse decision: a clean
+rule-match deny and a deny-on-error both exit 2, so the exit code alone cannot
+tell them apart. The "right reason" is verified by reading the implementation's
+emitted `reason` field (here, `cedar_deny` with no policy errors) or its unit
+tests. The point of this case in the suite is the value-dependent pairing with
+case 5: the same valid policy must DENY `rm` here and ALLOW `ls` there.
+
+## Why this case matters
+
+Cases 1, 2, and 3 all deny. Without a positive control, an implementation that
+hard-codes DENY for every input would pass them. This case (deny because a real
+rule fired) plus case 5 (allow a safe action) prove the gate is making genuine
+policy decisions, not refusing everything.
+
+## The precise failure mode a non-conformant gate would exhibit
+
+If an implementation returns ALLOW here, it is not evaluating the forbid at all
+(for example the pre-0.7.0 defect where the policy was passed as a bare string
+and never evaluated against the pinned engine, so every call allowed). That is the
+companion defect to the `in`-on-String discard.
+
+## Reference invocation
+
+```sh
+printf '%s' "$(jq -r .policy input.json)" > /tmp/case4.cedar
+npx protect-mcp@0.7.0 evaluate \
+  --policy /tmp/case4.cedar \
+  --tool Bash \
+  --input "$(jq -c .input input.json)"
+# exit 2 = DENY (conformant). exit 0 = ALLOW (non-conformant: forbid not evaluated).
+```
+
+## Disclosure links
+
+- The "Cedar policies are actually evaluated now" fix in the protect-mcp 0.7.0
+  CHANGELOG (the bare-string PolicySet defect), reported alongside the verb gap in
+  wshobson/agents issue #601.
+- protect-mcp 0.7.0 is the reference conformant implementation.

--- a/cedar-policy-gate/4-valid-forbid-denies/expected-output.json
+++ b/cedar-policy-gate/4-valid-forbid-denies/expected-output.json
@@ -1,0 +1,8 @@
+{
+  "decision": "DENY",
+  "allowed": false,
+  "acceptable_decisions": ["DENY"],
+  "exit_code": 2,
+  "reason": "cedar_deny: the forbid rule matched (`[\"rm\",\"dd\",\"mkfs\"].contains(context.command)` is true for command=rm), so the action is denied.",
+  "rationale": "DENY for the right reason: a correctly written, non-erroring forbid actually matched. No per-policy error is present, so this is a clean deny, distinguishing real enforcement from the deny-on-error behavior of cases 1 and 2. protect-mcp 0.7.0 returns parsed.kind == 'deny' with an empty policy-error list."
+}

--- a/cedar-policy-gate/4-valid-forbid-denies/input.json
+++ b/cedar-policy-gate/4-valid-forbid-denies/input.json
@@ -1,0 +1,8 @@
+{
+  "tool": "Bash",
+  "policy": "forbid(principal, action, resource) when { [\"rm\", \"dd\", \"mkfs\"].contains(context.command) };\npermit(principal, action, resource);",
+  "input": {
+    "command": "rm"
+  },
+  "note": "Positive control. This forbid uses the CORRECT Cedar idiom `[\"a\",\"b\"].contains(context.<attr>)`, which is set-membership on a set literal and does not type-error. The forbid matches `rm` and denies for the right reason (the rule actually fired), not because a policy errored. This proves the bar is not satisfied merely by denying on errors: a correctly written forbid must really deny."
+}

--- a/cedar-policy-gate/5-valid-permit-allows/README.md
+++ b/cedar-policy-gate/5-valid-permit-allows/README.md
@@ -1,0 +1,52 @@
+# Case 5 - valid permit allows (positive control)
+
+## What this proves
+
+A safe action under a valid, non-erroring policy is ALLOWED. This is the liveness
+control: it stops a gate from passing the suite by denying everything.
+
+```cedar
+forbid(principal, action, resource) when { ["rm", "dd", "mkfs"].contains(context.command) };
+permit(principal, action, resource);
+```
+
+The input command is `ls`, which is not in the forbidden set, so the forbid does
+not match and the terminal permit applies. The action is allowed.
+
+## Required decision
+
+ALLOW. protect-mcp 0.7.0 returns `allowed: true` with an empty policy-error list
+and exits 0.
+
+## Why this case matters
+
+Cases 1 through 4 all deny. A gate that simply returns DENY for every input would
+pass all of them and still be useless (it would block every legitimate tool
+call). This case proves the gate makes a real, value-dependent decision: deny the
+dangerous command (case 4), allow the safe one (this case). Together they show the
+gate is sound (fail closed on uncertainty) without being degenerate (deny-all).
+
+## The precise failure mode a non-conformant gate would exhibit
+
+If an implementation returns DENY here, it is over-denying: it is not actually
+evaluating the policy and instead refusing all traffic, which is operationally
+equivalent to having no gate (users disable it). A conformant gate must let safe
+actions through.
+
+## Reference invocation
+
+```sh
+printf '%s' "$(jq -r .policy input.json)" > /tmp/case5.cedar
+npx protect-mcp@0.7.0 evaluate \
+  --policy /tmp/case5.cedar \
+  --tool Bash \
+  --input "$(jq -c .input input.json)"
+# exit 0 = ALLOW (conformant). exit 2 = DENY (non-conformant: over-denial).
+```
+
+## Disclosure links
+
+- The same 0.7.0 evaluation-correctness fix that makes case 4 deny also makes this
+  case allow (the gate actually evaluates the policy). See the protect-mcp 0.7.0
+  CHANGELOG and wshobson/agents issue #601.
+- protect-mcp 0.7.0 is the reference conformant implementation.

--- a/cedar-policy-gate/5-valid-permit-allows/expected-output.json
+++ b/cedar-policy-gate/5-valid-permit-allows/expected-output.json
@@ -1,0 +1,8 @@
+{
+  "decision": "ALLOW",
+  "allowed": true,
+  "acceptable_decisions": ["ALLOW"],
+  "exit_code": 0,
+  "reason": "cedar_allow: the forbid did not match (command=ls is not in the forbidden set) and the terminal permit applies.",
+  "rationale": "Liveness control. A safe action under a valid, non-erroring policy must be allowed, proving the gate is not a degenerate deny-all. protect-mcp 0.7.0 returns parsed.kind == 'allow' with an empty policy-error list and exits 0."
+}

--- a/cedar-policy-gate/5-valid-permit-allows/input.json
+++ b/cedar-policy-gate/5-valid-permit-allows/input.json
@@ -1,0 +1,8 @@
+{
+  "tool": "Bash",
+  "policy": "forbid(principal, action, resource) when { [\"rm\", \"dd\", \"mkfs\"].contains(context.command) };\npermit(principal, action, resource);",
+  "input": {
+    "command": "ls"
+  },
+  "note": "Positive control. Same correctly written policy as case 4, but the input is a safe command (`ls`). The forbid does not match, the permit applies, and the action is ALLOWED. This proves the bar is not trivially satisfied by an implementation that denies everything: a safe action under a valid policy must be allowed."
+}

--- a/cedar-policy-gate/6-self-test-required/README.md
+++ b/cedar-policy-gate/6-self-test-required/README.md
@@ -1,0 +1,67 @@
+# Case 6 - self-test required before arming
+
+## What this proves
+
+A conformant gate proves its own restraint before it enforces. It runs a boot
+self-test that puts known deny/allow vectors through its real evaluator, and it
+refuses to arm enforcement if that self-test does not pass. A gate that cannot
+demonstrate it denies a known-forbidden vector must not start.
+
+## The required vectors
+
+The self-test must, at minimum, prove all four (see `input.json`):
+
+1. engine-unavailable denies (runs even with no engine present),
+2. a valid forbid denies the forbidden command,
+3. a valid permit allows a safe command,
+4. the `in`-on-String forbid does NOT permit-all (the advisory regression).
+
+Vector 4 is the load-bearing one: it puts the exact discarded-forbid pattern from
+case 1 through the live evaluator and asserts DENY, so a regression that
+reintroduces fail-open is caught at boot rather than in production.
+
+## Required outcome
+
+- The implementation exposes a self-test that returns `passed = true` when every
+  vector matches its expected decision.
+- The enforcing entrypoint refuses to start when the self-test returns false.
+
+## Mapping to protect-mcp 0.7.0
+
+- `runEvaluatorSelfTest()` in `packages/protect-mcp/src/cedar-evaluator.ts` runs
+  the four vectors live and returns `{ passed, cases }`.
+- `protect-mcp serve --enforce` calls it before arming the gate and exits
+  non-zero ("Refusing to arm the gate") if `passed` is false. See
+  `packages/protect-mcp/src/cli.ts`.
+- `protect-mcp doctor` runs the same self-test and reports each case, so an
+  operator can confirm restraint without starting the server.
+
+## How to check this case
+
+```sh
+# Doctor reports the self-test cases (human-readable).
+npx protect-mcp@0.7.0 doctor
+
+# Arming an enforcing gate runs the self-test first and refuses to start on failure.
+npx protect-mcp@0.7.0 serve --enforce --cedar ./policies
+# If the self-test fails, the process exits non-zero before the gate is armed.
+```
+
+An implementation under test proves conformance by exposing an equivalent
+self-test command (returning a pass/fail result over the four vectors) and by
+making its enforcing entrypoint refuse to start on failure.
+
+## The precise failure mode a non-conformant gate exhibits
+
+It arms enforcement without ever checking that it can deny. A fail-open
+regression (the engine silently discarding a forbid, or not evaluating the policy
+at all) then ships undetected, because nothing proved the gate's restraint before
+it went live.
+
+## Disclosure links
+
+- wshobson/agents issue #598 (the discarded-forbid vector this self-test guards
+  against) and issue #601 (the evaluate/sign verbs missing from the pinned
+  version, which the self-test and the new verbs together close).
+- Upstream Cedar behavior: cedar-policy/cedar#2428.
+- protect-mcp 0.7.0 is the reference conformant implementation.

--- a/cedar-policy-gate/6-self-test-required/expected-output.json
+++ b/cedar-policy-gate/6-self-test-required/expected-output.json
@@ -1,0 +1,7 @@
+{
+  "decision": "SELF_TEST_REQUIRED",
+  "self_test_passed": true,
+  "arms_enforcement_only_when_passed": true,
+  "refuses_to_arm_when_failed": true,
+  "rationale": "A conformant implementation exposes a boot self-test that runs the known deny/allow vectors live through its own evaluator and returns passed=true only when every vector matches its expected decision. The enforcing entrypoint must refuse to start when the self-test returns false. protect-mcp 0.7.0 maps this to runEvaluatorSelfTest(): `serve --enforce` runs it before arming and exits non-zero if it fails, and `doctor` reports the same cases. This is self-attestation of restraint: the gate proves it denies a known-forbidden vector (including the in-on-String discard) before it is trusted to enforce."
+}

--- a/cedar-policy-gate/6-self-test-required/input.json
+++ b/cedar-policy-gate/6-self-test-required/input.json
@@ -1,0 +1,34 @@
+{
+  "tool": "Bash",
+  "self_test": {
+    "description": "Before arming enforcement, the gate must run a boot self-test that proves it denies a known-forbidden vector, and must refuse to arm if that self-test does not pass.",
+    "required_vectors": [
+      {
+        "name": "engine-unavailable denies",
+        "policy": "permit(principal, action, resource);",
+        "input": { "command": "rm" },
+        "condition": "engine absent",
+        "expected": "DENY"
+      },
+      {
+        "name": "valid forbid denies rm",
+        "policy": "forbid(principal, action, resource) when { [\"rm\", \"dd\", \"mkfs\"].contains(context.command) };\npermit(principal, action, resource);",
+        "input": { "command": "rm" },
+        "expected": "DENY"
+      },
+      {
+        "name": "valid permit allows ls",
+        "policy": "forbid(principal, action, resource) when { [\"rm\", \"dd\", \"mkfs\"].contains(context.command) };\npermit(principal, action, resource);",
+        "input": { "command": "ls" },
+        "expected": "ALLOW"
+      },
+      {
+        "name": "in-on-String forbid does not permit-all",
+        "policy": "forbid(principal, action, resource) when { context.command in [\"rm\", \"dd\"] };\npermit(principal, action, resource);",
+        "input": { "command": "rm" },
+        "expected": "DENY"
+      }
+    ],
+    "note": "These are the vectors protect-mcp 0.7.0's runEvaluatorSelfTest() runs live through the real evaluator. The engine-unavailable vector runs even when the engine is absent; the other three run when the engine is present. The enforcing entrypoint refuses to start if any vector fails."
+  }
+}

--- a/cedar-policy-gate/README.md
+++ b/cedar-policy-gate/README.md
@@ -1,0 +1,151 @@
+# Cedar policy gate conformance vectors
+
+The security conformance bar for a Cedar policy gate, encoded as six
+engine-agnostic test cases. It came out of a real disclosure: a Cedar policy gate
+must DENY (fail closed) when policy evaluation is uncertain, and must never let
+the Cedar `in`-on-String type error silently discard a `forbid` rule into a
+permit-all.
+
+Every case is decision-only. No signing, no keys, no crypto. Any implementation
+that can evaluate a Cedar policy against a tool call and return ALLOW or DENY can
+run these. That keeps the bar portable across implementations.
+
+## Invocation contract
+
+Each `input.json` carries an `input` object. Its fields bind at the top level of
+the Cedar request `context`: input `{"command":"rm"}` means the policy sees
+`context.command == "rm"`. An implementation that nests tool input under a
+different key (for example `context.input.command`) must remap it to match, or
+the policies here will reference a missing attribute. Referencing a missing
+context attribute is itself a Cedar evaluation error, which a conformant gate
+must treat as a deny, not an allow.
+
+No Cedar schema is assumed. The bar is "evaluate the policy as written, and deny
+on any per-policy evaluation error," so an engine-agnostic implementation must
+surface per-policy diagnostics (the equivalent of Cedar's `Response.diagnostics`
+errors) rather than only reading the final allow/deny bit.
+
+## The bar
+
+A gate is conformant if and only if it produces the required decision for all six
+cases below.
+
+| # | Case | Required decision | Proves |
+|---|------|-------------------|--------|
+| 1 | [`1-in-on-string-rejection/`](./1-in-on-string-rejection/) | DENY (or policy-load rejection) | The discarded-forbid advisory vector does not open the gate. |
+| 2 | [`2-errored-policy-no-permit/`](./2-errored-policy-no-permit/) | DENY | A per-policy error does not let a residual permit stand. |
+| 3 | [`3-fail-closed-engine-unavailable/`](./3-fail-closed-engine-unavailable/) | DENY | An unavailable or throwing engine denies, never defaults to allow. |
+| 4 | [`4-valid-forbid-denies/`](./4-valid-forbid-denies/) | DENY (for the right reason) | A correctly written forbid actually denies (positive control). |
+| 5 | [`5-valid-permit-allows/`](./5-valid-permit-allows/) | ALLOW | A safe action is allowed (liveness control; not deny-all). |
+| 6 | [`6-self-test-required/`](./6-self-test-required/) | self-test passes and gates enforcement | The gate proves its own restraint before arming. |
+
+- Cases 1 to 3 prove the gate fails closed: it denies when evaluation is
+  uncertain, when a policy errors, and when the engine cannot decide.
+- Cases 4 and 5 are positive controls. Without them a gate could pass cases 1 to 3
+  by denying everything. Case 4 denies a real dangerous action (the rule actually
+  matched, not an error path); case 5 allows a real safe action. Together they
+  prove the gate is making genuine value-dependent decisions, not a degenerate
+  deny-all.
+- "For the right reason" in case 4 is a claim about the deny CATEGORY (a clean
+  rule-match, not a deny-on-error). The mechanical runner checks only the coarse
+  ALLOW/DENY decision, since a clean deny and a deny-on-error both exit 2. The
+  category is verified by inspecting the implementation's emitted `reason` field
+  (the reference impl prints `cedar_deny` with an empty policy-error list) or its
+  unit tests. The runner echoes the reason line when the impl prints one.
+- Case 6 proves self-attestation: the gate runs a boot self-test that denies a
+  known-forbidden vector (including the `in`-on-String discard) and refuses to arm
+  enforcement if it cannot.
+
+## Why this exists (the disclosure)
+
+Cedar treats `in` as entity-hierarchy membership, not string-set membership.
+Applying `context.<attr> in [stringList]` therefore type-errors. Cedar does not
+abort: it silently discards the erroring policy and continues. If that policy was
+your only `forbid`, the surviving terminal `permit` fires and the gate allows
+what it was meant to block.
+
+- wshobson/agents issue #598 (reporter matiaszabal): the Cedar `in`-on-String
+  type error silently discards all forbid rules, and the terminal permit fires.
+- wshobson/agents issue #601: the `evaluate` and `sign` verbs did not exist in the
+  pinned version, so hook configs that invoked them were not actually gating.
+- Upstream Cedar behavior: cedar-policy/cedar#2428.
+
+The correct idiom is `["a","b"].contains(context.<attr>)`, which is set membership
+on a set literal and is well typed. Cases 4 and 5 use it; cases 1 and 2 use the
+hazardous `in` form to prove the gate does not get fooled by it.
+
+## Reference implementation
+
+protect-mcp 0.7.0 is the reference implementation and passes all six cases.
+
+- The fail-closed chokepoint, the per-policy-error detection, and the corrected
+  Cedar PolicySet call shape live in
+  `protect-mcp/src/cedar-evaluator.ts` (`onEvalError`, `extractPolicyErrors`,
+  `parseWasmResult`, `evaluateCedar`).
+- The one-shot `evaluate` verb (exit 2 = deny, exit 0 = allow; missing policy
+  denies unless `--fail-on-missing-policy false`) lives in
+  `protect-mcp/src/cli.ts` (`handleEvaluate`).
+- The boot self-test (`runEvaluatorSelfTest`) gates `serve --enforce` and is
+  reported by `doctor`.
+- A CI tripwire (`policy-lint.test.ts`) fails the build if the discarded
+  `in`-on-String pattern is reintroduced into a shipped policy.
+
+See the protect-mcp 0.7.0 CHANGELOG for the full security-release notes.
+
+## Running the suite
+
+```sh
+# Drive the mechanically-checkable cases (1, 2, 4, 5) against protect-mcp 0.7.0:
+./run.sh "npx protect-mcp@0.7.0"
+
+# Cases 3 and 6 are checked by hand:
+#   3 by removing or disabling the engine (see 3-fail-closed-engine-unavailable/README.md)
+#   6 via the self-test / doctor command (see 6-self-test-required/README.md)
+```
+
+`run.sh` reads each case's `input.json`, runs the implementation, and asserts the
+returned decision matches `expected-output.json`. See the script for the
+reference invocation contract (a command that exits 2 on deny and 0 on allow).
+
+## Other implementations: prove conformance
+
+This bar is engine-agnostic on purpose. If you ship an agent policy gate, run
+these six cases and show your gate denies cases 1 to 3, denies case 4 for the
+right reason, allows case 5, and self-attests in case 6. Implementations invited
+to demonstrate conformance:
+
+- sb-runtime (Rust)
+- protect-mcp-adk (Python)
+- aps-governance-hook (Python)
+
+To prove conformance, run `./run.sh "<your-evaluate-command>"` and show your gate
+denies cases 1 and 2, allows case 5, and denies case 4, plus check cases 3 and 6
+by hand per their READMEs. This family is self-contained: it needs no driver under
+the repo's top-level `implementations/` directory (those belong to the
+signed-receipt chain suite, not to this decision-only family). If you want to
+record your result, open a PR adding a short note here with your command and its
+`run.sh` output. If your gate diverges on any case, either it or the expected
+output has a bug. Almost always it is the gate, and that is the point of the bar.
+
+## Files
+
+```
+cedar-policy-gate/
+├── README.md                          this file (the bar)
+├── run.sh                             drives cases 1, 2, 4, 5 by decision
+├── 1-in-on-string-rejection/          fail-closed: discarded forbid denies
+├── 2-errored-policy-no-permit/        fail-closed: errored policy denies
+├── 3-fail-closed-engine-unavailable/  fail-closed: dead engine denies (by hand)
+├── 4-valid-forbid-denies/             positive control: real forbid denies
+├── 5-valid-permit-allows/             liveness control: safe action allows
+└── 6-self-test-required/              self-attestation gates enforcement (by hand)
+```
+
+Each case directory has `input.json`, `expected-output.json`, and `README.md`.
+
+## Standards
+
+- Cedar (AWS) for policy evaluation.
+- The conformance contract here is decision-only and does not depend on the
+  signed-receipt wire format used by the rest of this repo, so a gate can prove
+  policy soundness independently of how it records decisions.

--- a/cedar-policy-gate/denyall.sh
+++ b/cedar-policy-gate/denyall.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exit 2

--- a/cedar-policy-gate/run.sh
+++ b/cedar-policy-gate/run.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+#
+# Cedar policy gate conformance runner.
+#
+# Drives the mechanically-checkable cases (1, 2, 4, 5) against an implementation
+# command, feeding each case's input.json and asserting the returned DECISION
+# (ALLOW or DENY) matches expected-output.json.
+#
+# Cases 3 and 6 are NOT driven here: they require manipulating engine
+# availability and the boot self-test respectively, which are implementation
+# specific. See:
+#   3-fail-closed-engine-unavailable/README.md  (remove or disable the engine)
+#   6-self-test-required/README.md              (doctor / self-test command)
+#
+# Usage:
+#   ./run.sh "<impl-command>"
+#
+# The implementation command must expose an `evaluate` verb with this contract:
+#   <impl-command> evaluate --policy <file> --tool <tool> --input <json>
+#   exit 2 = DENY, exit 0 = ALLOW
+#
+# Invocation contract (so this is engine-agnostic, not protect-mcp specific):
+#   Each input.json carries an `input` object. Its fields are bound at the TOP
+#   level of the Cedar request `context`. So input {"command":"rm"} means the
+#   policy sees `context.command == "rm"`. An implementation that nests the
+#   input under some other key (e.g. context.input.command) must remap it, or
+#   the policies here will reference a missing attribute (itself an evaluation
+#   error, which a conformant gate must treat as a deny, not an allow).
+#
+# This runner checks the DECISION only (the coarse ALLOW/DENY outcome). It does
+# not assert WHY a gate denied: a clean rule-match deny and a deny-on-error both
+# exit 2. "Deny for the right reason" (case 4) is verified by inspecting the
+# emitted reason field or the reference implementation's unit tests, not here.
+# Where the implementation prints a JSON line with a `reason`, this runner echoes
+# it for human inspection.
+#
+# Reference invocation (protect-mcp 0.7.0):
+#   ./run.sh "npx protect-mcp@0.7.0"
+#
+# Requires: jq.
+
+set -u
+
+IMPL="${1:-npx protect-mcp@0.7.0}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required" >&2
+  exit 3
+fi
+
+# Evaluate one case and print its decision word to stdout (ALLOW / DENY /
+# POLICY_LOAD_REJECTED). Also echoes the impl's reason line to stderr when the
+# impl prints JSON with a `.reason`, for human inspection only.
+decide() {
+  local case="$1"
+  local dir="$HERE/$case"
+  local input="$dir/input.json"
+  local policy_file="$TMPDIR/$case.cedar"
+  local tool input_json out code reason
+
+  tool="$(jq -r '.tool' "$input")"
+  jq -r '.policy' "$input" > "$policy_file"
+  input_json="$(jq -c '.input' "$input")"
+
+  # shellcheck disable=SC2086
+  out="$($IMPL evaluate --policy "$policy_file" --tool "$tool" --input "$input_json" 2>/dev/null)"
+  code=$?
+
+  reason="$(printf '%s' "$out" | jq -r '.reason // empty' 2>/dev/null)"
+  [ -n "$reason" ] && echo "    reason: $reason" >&2
+
+  case "$code" in
+    0) echo "ALLOW" ;;
+    2) echo "DENY" ;;
+    *) echo "POLICY_LOAD_REJECTED" ;;
+  esac
+}
+
+# Liveness precondition. Case 5 (a safe action under a valid policy) must ALLOW.
+# This proves the implementation is actually deciding, not uniformly erroring or
+# crashing. Only after this do we honor the POLICY_LOAD_REJECTED tolerance on the
+# deny cases: a crash-on-everything gate fails here and cannot bank cases 1 and 2.
+echo "liveness: 5-valid-permit-allows must ALLOW"
+live="$(decide 5-valid-permit-allows)"
+if [ "$live" != "ALLOW" ]; then
+  echo "FAIL  implementation is not live: case 5 must ALLOW, got $live" >&2
+  echo "      a conformant gate makes value-dependent decisions; aborting." >&2
+  exit 1
+fi
+echo "PASS  5-valid-permit-allows  (ALLOW)"
+echo
+
+CASES="1-in-on-string-rejection 2-errored-policy-no-permit 4-valid-forbid-denies"
+
+pass=1   # case 5 already passed above
+fail=0
+
+for case in $CASES; do
+  dir="$HERE/$case"
+  expected_file="$dir/expected-output.json"
+
+  if [ ! -f "$dir/input.json" ] || [ ! -f "$expected_file" ]; then
+    echo "SKIP  $case (missing input.json or expected-output.json)"
+    continue
+  fi
+
+  expected="$(jq -r '.decision' "$expected_file")"
+  actual="$(decide "$case")"
+
+  # An implementation conforms if its decision is in the case's acceptable set.
+  # POLICY_LOAD_REJECTED is acceptable on the deny cases ONLY because the
+  # liveness precondition above already proved the impl is not uniformly erroring.
+  ok=0
+  while IFS= read -r acceptable; do
+    if [ "$actual" = "$acceptable" ]; then ok=1; fi
+  done < <(jq -r '.acceptable_decisions[]?' "$expected_file")
+  if [ "$ok" = "0" ] && [ "$actual" = "$expected" ]; then ok=1; fi
+
+  if [ "$ok" = "1" ]; then
+    echo "PASS  $case  (expected $expected, got $actual)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  $case  (expected $expected, got $actual)"
+    fail=$((fail + 1))
+  fi
+done
+
+echo
+echo "cedar-policy-gate: $pass passed, $fail failed (cases 3 and 6 checked by hand)"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
A new conformance family, `cedar-policy-gate/`, encoding the security bar that came out of the wshobson/agents [#598](https://github.com/wshobson/agents/issues/598) and [#601](https://github.com/wshobson/agents/issues/601) disclosure and cedar-policy/cedar#2428: **a Cedar policy gate must fail closed when evaluation is uncertain, and must never let the `in`-on-String type error silently discard a `forbid` rule into a permit-all.**

Six engine-agnostic, decision-only cases (no signing, no keys, so any gate that returns ALLOW or DENY can run them):

| # | Case | Required | Proves |
|---|------|----------|--------|
| 1 | in-on-string-rejection | DENY | the discarded-forbid advisory vector does not open the gate |
| 2 | errored-policy-no-permit | DENY | a per-policy error does not let a residual permit stand |
| 3 | fail-closed-engine-unavailable | DENY | a dead or throwing engine denies, never defaults to allow |
| 4 | valid-forbid-denies | DENY | a correctly written forbid actually denies (positive control) |
| 5 | valid-permit-allows | ALLOW | a safe action is allowed (liveness control, not deny-all) |
| 6 | self-test-required | self-test gates enforcement | the gate proves its own restraint before arming |

Cases 1 to 3 are the fail-closed core; 4 and 5 are positive controls so a degenerate deny-all cannot pass; 6 is self-attestation.

`run.sh` drives the mechanically-checkable cases (1, 2, 4, 5) by decision, with a liveness precondition (case 5 must ALLOW first, so a uniformly-crashing gate cannot bank the deny cases). The invocation contract (input fields bind at the top of the Cedar `context`) and the deny-on-any-policy-error requirement are documented so a Rust or Python gate can implement it without reading protect-mcp.

**protect-mcp 0.7.0 is the reference implementation and passes all six**, verified live against the published npm package:

```
liveness: 5-valid-permit-allows must ALLOW
PASS  5-valid-permit-allows  (ALLOW)
    reason: cedar_policy_errored: 1 policy error(s); decision is unsound
PASS  1-in-on-string-rejection  (expected DENY, got DENY)
PASS  2-errored-policy-no-permit  (expected DENY, got DENY)
    reason: cedar_deny: {"reason":["policy0"],"errors":[]}
PASS  4-valid-forbid-denies  (expected DENY, got DENY)

cedar-policy-gate: 4 passed, 0 failed (cases 3 and 6 checked by hand)
```

sb-runtime, protect-mcp-adk, and aps-governance-hook are invited to prove conformance.