### PR TITLE
test: add evidence predicate conformance vectors

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -20,7 +20,10 @@ jobs:
           python-version: '3.12'
 
       - name: Make scripts executable
-        run: chmod +x conformance/*.sh implementations/*/run.sh
+        run: chmod +x conformance/*.sh implementations/*/run.sh evidence-predicate/run.sh
+
+      - name: Verify evidence predicate vectors
+        run: ./evidence-predicate/run.sh
 
       - name: Run all implementation drivers
         run: ./conformance/run.sh

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ implementations/
 
 For APS, A2A, Hermes, and ACTA interop, this repo follows one rule: compose by content-hash reference, not by re-signing another system's receipt. See [docs/composition-conformance.md](docs/composition-conformance.md).
 
+## Evidence predicate conformance
+
+[`evidence-predicate/`](evidence-predicate/) is a separate semantic suite for
+the proposed `evidence` predicate. It verifies that a receipt cannot turn a
+named source or a copied key identifier into independent corroboration. The
+suite is dependency-free and runs in CI with the receipt conformance checks.
+
 ## Running locally
 
 ```bash

--- a/evidence-predicate/README.md
+++ b/evidence-predicate/README.md
@@ -1,0 +1,57 @@
+# Evidence Predicate Conformance Vectors
+
+This directory defines dependency-free reference vectors for the `evidence`
+predicate proposed in `draft-farley-acta-signed-receipts-03`.
+
+The predicate distinguishes an assertion present inside a receipt from an
+independent corroborating assertion. A named `authority` or matching `kid` is
+never enough. The relying party must verify `source.sig` under an
+out-of-band-pinned source key and determine that the key belongs to a control
+domain distinct from the receipt signer.
+
+## Run
+
+```bash
+./evidence-predicate/run.sh
+```
+
+The suite regenerates no artifacts in check mode. It fails if a committed
+fixture is stale or if any expected verification result changes.
+
+## Vector Set
+
+| Vector | Result | What it proves |
+| --- | --- | --- |
+| `01-independent-corroboration` | independent | A custodian source key is pinned, distinct, and signs the reconstructed claim. |
+| `02-independent-without-as-of` | independent | `as_of` is omitted from the signed claim when it is absent from the evidence entry. It is never encoded as `null`. |
+| `03-forged-trusted-kid` | not independent | Copying a trusted source `kid` does not work when the source signature does not verify under that key. |
+| `04-self-corroboration` | not independent | A receipt signer cannot use its own pinned key to manufacture independent corroboration. |
+
+`invalid/null-as-of-entry.json` is a structural negative fixture. It confirms
+that `as_of` may be absent but may not be encoded as `null`.
+
+## Artifact Shape
+
+Each vector contains:
+
+- `receipt.json`: a signed, compact test receipt;
+- `source-claim.json`: the exact reconstructed claim signed by `source.sig`;
+- `expected.json`: expected receipt, source, and independence verdicts.
+
+`schema/evidence-entry.schema.json` supplies the corresponding JSON Schema.
+
+`trust-policy.json` is deliberately outside every receipt. It represents the
+relying party's out-of-band trust policy and records both public keys and
+control domains. This distinction is load-bearing: public-key inequality by
+itself does not prove independent control.
+
+The included script only implements the subset of JCS exercised by these
+fixtures: ASCII member names, finite integers, and strings. It is adequate to
+make the fixtures reproducible, but production implementations MUST use a
+complete RFC 8785 implementation.
+
+## Scope
+
+These are semantic conformance vectors for the evidence predicate. They do
+not replace a full receipt-format compatibility suite or provide a production
+key directory. The deterministic test keys are public and MUST NOT be reused.

--- a/evidence-predicate/invalid/null-as-of-entry.json
+++ b/evidence-predicate/invalid/null-as-of-entry.json
@@ -1,0 +1,11 @@
+{
+  "dimension": "provenance",
+  "state": "verified",
+  "as_of": null,
+  "source": {
+    "authority": "custodian:demo",
+    "ref": "sha256:6e0a9aa1f9d5c8ce3d545fb7b1d452f84514e93f493f94f24fa7c8180cb49ac4",
+    "kid": "test:custodian:demo:ed25519",
+    "sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+  }
+}

--- a/evidence-predicate/lib.mjs
+++ b/evidence-predicate/lib.mjs
@@ -1,0 +1,70 @@
+// Minimal, dependency-free crypto helpers for the evidence predicate vectors.
+//
+// The fixtures use only finite integers and ASCII strings. For that restricted
+// value set, sorted-key JSON serialization is byte-for-byte JCS. Production
+// implementations MUST use a complete RFC 8785 implementation.
+
+import crypto from 'node:crypto'
+
+const PRIVATE_PKCS8_PREFIX = Buffer.from('302e020100300506032b657004220420', 'hex')
+const PUBLIC_SPKI_PREFIX = Buffer.from('302a300506032b6570032100', 'hex')
+
+export function canonicalize(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(',')}]`
+
+  return `{${Object.keys(value).sort().map((key) =>
+    `${JSON.stringify(key)}:${canonicalize(value[key])}`
+  ).join(',')}}`
+}
+
+export function keyPairFromSeed(seedHex) {
+  const seed = Buffer.from(seedHex, 'hex')
+  if (seed.length !== 32) throw new Error('Ed25519 seed must be 32 bytes')
+
+  const privateKey = crypto.createPrivateKey({
+    key: Buffer.concat([PRIVATE_PKCS8_PREFIX, seed]),
+    format: 'der',
+    type: 'pkcs8',
+  })
+  const publicDer = crypto.createPublicKey(privateKey).export({ type: 'spki', format: 'der' })
+  return { privateKey, publicKeyHex: publicDer.subarray(-32).toString('hex') }
+}
+
+export function publicKeyFromHex(publicKeyHex) {
+  const raw = Buffer.from(publicKeyHex, 'hex')
+  if (raw.length !== 32) throw new Error('Ed25519 public key must be 32 bytes')
+  return crypto.createPublicKey({
+    key: Buffer.concat([PUBLIC_SPKI_PREFIX, raw]),
+    format: 'der',
+    type: 'spki',
+  })
+}
+
+export function signHex(value, privateKey) {
+  return crypto.sign(null, Buffer.from(canonicalize(value), 'utf8'), privateKey).toString('hex')
+}
+
+export function verifyHex(value, signatureHex, publicKeyHex) {
+  if (!/^[0-9a-f]{128}$/.test(signatureHex || '')) return false
+  return crypto.verify(
+    null,
+    Buffer.from(canonicalize(value), 'utf8'),
+    publicKeyFromHex(publicKeyHex),
+    Buffer.from(signatureHex, 'hex'),
+  )
+}
+
+export function sha256Hex(value) {
+  return crypto.createHash('sha256').update(Buffer.from(canonicalize(value), 'utf8')).digest('hex')
+}
+
+export function evidenceClaim(entry) {
+  const claim = {
+    dimension: entry.dimension,
+    ref: entry.source.ref,
+    state: entry.state,
+  }
+  if (Object.hasOwn(entry, 'as_of')) claim.as_of = entry.as_of
+  return claim
+}

--- a/evidence-predicate/run.sh
+++ b/evidence-predicate/run.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+node "$ROOT/scripts/generate.mjs" --check
+node "$ROOT/scripts/verify.mjs"

--- a/evidence-predicate/schema/evidence-entry.schema.json
+++ b/evidence-predicate/schema/evidence-entry.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://scopeblind.com/schemas/evidence-entry.v1.schema.json",
+  "title": "ScopeBlind Evidence Predicate Entry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["dimension", "state", "source"],
+  "properties": {
+    "dimension": {
+      "type": "string",
+      "minLength": 1
+    },
+    "state": {
+      "enum": ["verified", "failed", "unknown", "not_applicable"]
+    },
+    "as_of": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["authority", "ref"],
+      "properties": {
+        "authority": { "type": "string", "minLength": 1 },
+        "ref": { "type": "string", "minLength": 1 },
+        "kid": { "type": "string", "minLength": 1 },
+        "sig": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{128}$"
+        }
+      }
+    }
+  }
+}

--- a/evidence-predicate/scripts/generate.mjs
+++ b/evidence-predicate/scripts/generate.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+// Deterministically generate the evidence predicate reference vectors.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { evidenceClaim, keyPairFromSeed, sha256Hex, signHex } from '../lib.mjs'
+
+const ROOT = path.dirname(path.dirname(fileURLToPath(import.meta.url)))
+const CHECK = process.argv.includes('--check')
+const RECEIPT = keyPairFromSeed('0000000000000000000000000000000000000000000000000000000000000001')
+const CUSTODIAN = keyPairFromSeed('0000000000000000000000000000000000000000000000000000000000000002')
+
+const receiptKid = 'test:manager:meridian:ed25519'
+const custodianKid = 'test:custodian:demo:ed25519'
+
+const trustPolicy = {
+  type: 'scopeblind.evidence_trust_policy.v1',
+  receipt_signers: {
+    [receiptKid]: {
+      public_key_hex: RECEIPT.publicKeyHex,
+      control_domain: 'manager:meridian',
+    },
+  },
+  source_keys: {
+    [custodianKid]: {
+      public_key_hex: CUSTODIAN.publicKeyHex,
+      control_domain: 'custodian:demo',
+    },
+    [receiptKid]: {
+      public_key_hex: RECEIPT.publicKeyHex,
+      control_domain: 'manager:meridian',
+    },
+  },
+}
+
+function makeEvidence({ asOf, sourceKey, sourceKid, authority = 'custodian:demo' }) {
+  const entry = {
+    dimension: 'provenance',
+    state: 'verified',
+    source: {
+      authority,
+      ref: 'sha256:6e0a9aa1f9d5c8ce3d545fb7b1d452f84514e93f493f94f24fa7c8180cb49ac4',
+      kid: sourceKid,
+    },
+    ...(asOf ? { as_of: asOf } : {}),
+  }
+  entry.source.sig = signHex(evidenceClaim(entry), sourceKey.privateKey)
+  return entry
+}
+
+function makeReceipt({ id, evidence }) {
+  const unsigned = {
+    type: 'scopeblind.receipt.v1',
+    algorithm: 'ed25519',
+    kid: receiptKid,
+    issuer: 'manager:meridian',
+    issued_at: '2026-07-11T12:00:00Z',
+    payload: {
+      decision: 'deny',
+      action: { kind: 'trade.submit', target: 'restricted-security' },
+      receipt_id: id,
+      evidence: [evidence],
+    },
+  }
+  return { ...unsigned, signature: signHex(unsigned, RECEIPT.privateKey) }
+}
+
+const sourceAsOf = '2026-07-11T11:59:00Z'
+const independent = makeEvidence({ asOf: sourceAsOf, sourceKey: CUSTODIAN, sourceKid: custodianKid })
+const noAsOf = makeEvidence({ sourceKey: CUSTODIAN, sourceKid: custodianKid })
+const forgedKid = makeEvidence({ asOf: sourceAsOf, sourceKey: RECEIPT, sourceKid: custodianKid })
+const selfCorroboration = makeEvidence({ asOf: sourceAsOf, sourceKey: RECEIPT, sourceKid: receiptKid, authority: 'manager:meridian' })
+
+const vectors = [
+  {
+    id: '01-independent-corroboration',
+    receipt: makeReceipt({ id: 'evidence-01', evidence: independent }),
+    expected: {
+      receipt_signature_valid: true,
+      source_signature_valid: true,
+      source_key_out_of_band: true,
+      source_key_distinct: true,
+      source_control_domain_distinct: true,
+      independent_corroboration: true,
+      reason: 'independent_source_signature_verified',
+    },
+  },
+  {
+    id: '02-independent-without-as-of',
+    receipt: makeReceipt({ id: 'evidence-02', evidence: noAsOf }),
+    expected: {
+      receipt_signature_valid: true,
+      source_signature_valid: true,
+      source_key_out_of_band: true,
+      source_key_distinct: true,
+      source_control_domain_distinct: true,
+      independent_corroboration: true,
+      reason: 'independent_source_signature_verified',
+      signed_claim_omits_as_of: true,
+    },
+  },
+  {
+    id: '03-forged-trusted-kid',
+    receipt: makeReceipt({ id: 'evidence-03', evidence: forgedKid }),
+    expected: {
+      receipt_signature_valid: true,
+      source_signature_valid: false,
+      source_key_out_of_band: true,
+      source_key_distinct: true,
+      source_control_domain_distinct: true,
+      independent_corroboration: false,
+      reason: 'source_signature_invalid',
+    },
+  },
+  {
+    id: '04-self-corroboration',
+    receipt: makeReceipt({ id: 'evidence-04', evidence: selfCorroboration }),
+    expected: {
+      receipt_signature_valid: true,
+      source_signature_valid: true,
+      source_key_out_of_band: true,
+      source_key_distinct: false,
+      source_control_domain_distinct: false,
+      independent_corroboration: false,
+      reason: 'source_key_not_independent',
+    },
+  },
+]
+
+function json(value) {
+  return `${JSON.stringify(value, null, 2)}\n`
+}
+
+function writeOrCheck(file, content) {
+  if (CHECK) {
+    if (!fs.existsSync(file) || fs.readFileSync(file, 'utf8') !== content) {
+      throw new Error(`stale generated artifact: ${path.relative(ROOT, file)}`)
+    }
+    return
+  }
+  fs.mkdirSync(path.dirname(file), { recursive: true })
+  fs.writeFileSync(file, content)
+}
+
+writeOrCheck(path.join(ROOT, 'trust-policy.json'), json(trustPolicy))
+for (const vector of vectors) {
+  const dir = path.join(ROOT, 'vectors', vector.id)
+  writeOrCheck(path.join(dir, 'receipt.json'), json(vector.receipt))
+  writeOrCheck(path.join(dir, 'expected.json'), json({
+    ...vector.expected,
+    receipt_digest: `sha256:${sha256Hex(vector.receipt)}`,
+  }))
+  writeOrCheck(path.join(dir, 'source-claim.json'), json(evidenceClaim(vector.receipt.payload.evidence[0])))
+}
+
+console.log(`${CHECK ? 'checked' : 'generated'} ${vectors.length} evidence predicate vectors`)

--- a/evidence-predicate/scripts/verify.mjs
+++ b/evidence-predicate/scripts/verify.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// Verify the evidence predicate vectors without project-specific dependencies.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { evidenceClaim, sha256Hex, verifyHex } from '../lib.mjs'
+
+const ROOT = path.dirname(path.dirname(fileURLToPath(import.meta.url)))
+const trust = JSON.parse(fs.readFileSync(path.join(ROOT, 'trust-policy.json'), 'utf8'))
+const vectorsDir = path.join(ROOT, 'vectors')
+const ids = fs.readdirSync(vectorsDir).filter((name) => /^\d\d-/.test(name)).sort()
+let failures = 0
+
+function fail(id, message) {
+  failures += 1
+  console.error(`${id}: ${message}`)
+}
+
+function validateEvidenceEntry(entry) {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return 'entry must be an object'
+  const allowed = new Set(['dimension', 'state', 'source', 'as_of'])
+  for (const key of Object.keys(entry)) if (!allowed.has(key)) return `unknown field ${key}`
+  if (typeof entry.dimension !== 'string' || entry.dimension.length === 0) return 'dimension must be a non-empty string'
+  if (!['verified', 'failed', 'unknown', 'not_applicable'].includes(entry.state)) return 'invalid state'
+  if (Object.hasOwn(entry, 'as_of') && typeof entry.as_of !== 'string') return 'as_of must be omitted or an RFC 3339 string'
+  if (!entry.source || typeof entry.source !== 'object' || Array.isArray(entry.source)) return 'source must be an object'
+  const sourceAllowed = new Set(['authority', 'ref', 'kid', 'sig'])
+  for (const key of Object.keys(entry.source)) if (!sourceAllowed.has(key)) return `unknown source field ${key}`
+  if (typeof entry.source.authority !== 'string' || entry.source.authority.length === 0) return 'source.authority must be a non-empty string'
+  if (typeof entry.source.ref !== 'string' || entry.source.ref.length === 0) return 'source.ref must be a non-empty string'
+  if (entry.source.kid !== undefined && (typeof entry.source.kid !== 'string' || entry.source.kid.length === 0)) return 'source.kid must be a non-empty string'
+  if (entry.source.sig !== undefined && !/^[0-9a-f]{128}$/.test(entry.source.sig)) return 'source.sig must be 128 lowercase hex characters'
+  return null
+}
+
+for (const id of ids) {
+  const dir = path.join(vectorsDir, id)
+  const receipt = JSON.parse(fs.readFileSync(path.join(dir, 'receipt.json'), 'utf8'))
+  const expected = JSON.parse(fs.readFileSync(path.join(dir, 'expected.json'), 'utf8'))
+  const evidence = receipt?.payload?.evidence?.[0]
+  const receiptSigner = trust.receipt_signers[receipt.kid]
+  const sourceSigner = evidence?.source?.kid ? trust.source_keys[evidence.source.kid] : null
+
+  const schemaError = validateEvidenceEntry(evidence)
+  if (schemaError) {
+    fail(id, `evidence entry schema violation: ${schemaError}`)
+    continue
+  }
+
+  if (!receiptSigner) {
+    fail(id, 'receipt signer is not pinned by the out-of-band trust policy')
+    continue
+  }
+  const { signature, ...unsignedReceipt } = receipt
+  const result = {
+    receipt_signature_valid: verifyHex(unsignedReceipt, signature, receiptSigner.public_key_hex),
+    source_signature_valid: sourceSigner ? verifyHex(evidenceClaim(evidence), evidence?.source?.sig, sourceSigner.public_key_hex) : false,
+    source_key_out_of_band: Boolean(sourceSigner),
+    source_key_distinct: Boolean(sourceSigner && sourceSigner.public_key_hex !== receiptSigner.public_key_hex),
+    source_control_domain_distinct: Boolean(sourceSigner && sourceSigner.control_domain !== receiptSigner.control_domain),
+  }
+  result.independent_corroboration = Boolean(
+    result.receipt_signature_valid &&
+    result.source_signature_valid &&
+    result.source_key_out_of_band &&
+    result.source_key_distinct &&
+    result.source_control_domain_distinct,
+  )
+  result.reason = !result.receipt_signature_valid ? 'receipt_signature_invalid'
+    : !result.source_key_out_of_band ? 'source_key_not_pinned'
+    : !result.source_signature_valid ? 'source_signature_invalid'
+    : !result.source_key_distinct || !result.source_control_domain_distinct ? 'source_key_not_independent'
+    : 'independent_source_signature_verified'
+
+  const signedClaimOmitsAsOf = !Object.hasOwn(evidenceClaim(evidence), 'as_of')
+  for (const [key, value] of Object.entries(expected)) {
+    if (key === 'receipt_digest') continue
+    if (key === 'signed_claim_omits_as_of') {
+      if (signedClaimOmitsAsOf !== value) fail(id, `${key}: expected ${JSON.stringify(value)}, got ${JSON.stringify(signedClaimOmitsAsOf)}`)
+      continue
+    }
+    if (result[key] !== value) fail(id, `${key}: expected ${JSON.stringify(value)}, got ${JSON.stringify(result[key])}`)
+  }
+  const expectedDigest = `sha256:${sha256Hex(receipt)}`
+  if (expected.receipt_digest !== expectedDigest) fail(id, 'receipt digest does not match expected artifact')
+  if (id === '02-independent-without-as-of' && !signedClaimOmitsAsOf) {
+    fail(id, 'claim contains as_of when evidence omitted it')
+  }
+  if (failures === 0) console.log(`${id}: ${result.independent_corroboration ? 'independent' : 'not independent'} (${result.reason})`)
+}
+
+const nullAsOf = JSON.parse(fs.readFileSync(path.join(ROOT, 'invalid', 'null-as-of-entry.json'), 'utf8'))
+if (validateEvidenceEntry(nullAsOf) !== 'as_of must be omitted or an RFC 3339 string') {
+  fail('invalid/null-as-of-entry', 'nullable as_of was not rejected')
+} else {
+  console.log('invalid/null-as-of-entry: rejected nullable as_of')
+}
+
+if (failures) process.exit(1)
+console.log(`verified ${ids.length} evidence predicate vectors`)

--- a/evidence-predicate/trust-policy.json
+++ b/evidence-predicate/trust-policy.json
@@ -1,0 +1,19 @@
+{
+  "type": "scopeblind.evidence_trust_policy.v1",
+  "receipt_signers": {
+    "test:manager:meridian:ed25519": {
+      "public_key_hex": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+      "control_domain": "manager:meridian"
+    }
+  },
+  "source_keys": {
+    "test:custodian:demo:ed25519": {
+      "public_key_hex": "7422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe2674",
+      "control_domain": "custodian:demo"
+    },
+    "test:manager:meridian:ed25519": {
+      "public_key_hex": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
+      "control_domain": "manager:meridian"
+    }
+  }
+}

--- a/evidence-predicate/vectors/01-independent-corroboration/expected.json
+++ b/evidence-predicate/vectors/01-independent-corroboration/expected.json
@@ -1,0 +1,10 @@
+{
+  "receipt_signature_valid": true,
+  "source_signature_valid": true,
+  "source_key_out_of_band": true,
+  "source_key_distinct": true,
+  "source_control_domain_distinct": true,
+  "independent_corroboration": true,
+  "reason": "independent_source_signature_verified",
+  "receipt_digest": "sha256:1eaec5d702b93c492d515843ae8356f7c8b0266a69847233aecca822eb8f88cb"
+}

--- a/evidence-predicate/vectors/01-independent-corroboration/receipt.json
+++ b/evidence-predicate/vectors/01-independent-corroboration/receipt.json
@@ -1,0 +1,29 @@
+{
+  "type": "scopeblind.receipt.v1",
+  "algorithm": "ed25519",
+  "kid": "test:manager:meridian:ed25519",
+  "issuer": "manager:meridian",
+  "issued_at": "2026-07-11T12:00:00Z",
+  "payload": {
+    "decision": "deny",
+    "action": {
+      "kind": "trade.submit",
+      "target": "restricted-security"
+    },
+    "receipt_id": "evidence-01",
+    "evidence": [
+      {
+        "dimension": "provenance",
+        "state": "verified",
+        "source": {
+          "authority": "custodian:demo",
+          "ref": "sha256:6e0a9aa1f9d5c8ce3d545fb7b1d452f84514e93f493f94f24fa7c8180cb49ac4",
+          "kid": "test:custodian:demo:ed25519",
+          "sig": "f4c7bd013ff8659db8b70ae14411b07e4c45e256861372e1062fb307ba364a64d011aaeb649a62a121f109650d4c78019d30bdf27f02e3c1b291be2db2c9fe07"
+        },
+        "as_of": "2026-07-11T11:59:00Z"
+      }
+    ]
+  },
+  "signature": "097ca9fa38120c62073091adee50207fd72ffa4ab138f9c2d4c9998080f80e6746c616ea29826864b446a484b1c44eeaeaaad2062009cdc699b117c67b3a5d09"
+}

--- a/evidence-predicate/vectors/01-independent-corroboration/source-claim.json
+++ b/evidence-predicate/vectors/01-independent-corroboration/source-claim.json
@@ -1,0 +1,6 @@
+{
+  "dimension": "provenance",
+  "ref": "sha256:6e0a9aa1f9d5c8ce3d545fb7b1d452f84514e93f493f94f24fa7c8180cb49ac4",
+  "state": "verified",
+  "as_of": "2026-07-11T11:59:00Z"
+}

--- a/evidence-predicate/vectors/02-independent-without-as-of/expected.json
+++ b/evidence-predicate/vectors/02-independent-without-as-of/expected.json
@@ -1,0 +1,11 @@
+{
+  "receipt_signature_valid": true,
+  "source_signature_valid": true,
+  "source_key_out_of_band": true,
+  "source_key_distinct": true,
+  "source_control_domain_distinct": true,
+  "independent_corroboration": true,
+  "reason": "independent_source_signature_verified",
+  "signed_claim_omits_as_of": true,
+  "receipt_digest": "sha256:564125a8d56384e37342c653fb0568713a51c2cd1a5a4ac2f572a161eda5993e"
+}

--- a/evidence-predicate/vectors/02-independent-without-as-of/receipt.json
+++ b/evidence-predicate/vectors/02-independent-without-as-of/receipt.json
@@ -1,0 +1,28 @@
+{
+  "type": "scopeblind.receipt.v1",
+  "algorithm": "ed25519",
+  "kid": "test:manager:meridian:ed25519",
+  "issuer": "manager:meridian",
+  "issued_at": "2026-07-11T12:00:00Z",
+  "payload": {
+    "decision": "deny",
+    "action": {
+      "kind": "trade.submit",
+      "target": "restricted-security"
+    },
+    "receipt_id": "evidence-02",
+    "evidence": [
+      {
+        "dimension": "provenance",
+        "state": "verified",
+        "source": {
+          "authority": "custodian:demo",
+          "ref": "sha256:6e0a9aa1f9d5c8ce3d545fb7b1d452f84514e93f493f94f24fa7c8180cb49ac4",
+          "kid": "test:custodian:demo:ed25519",
+          "sig": "ba178689e57d6f44316a8d8d7f34050339aa7f30a6d4fc7a3d28347752ebefa4f04330b3413da7499945188b878143aa473af6c7b6f03d96b7da4ef39ba7920e"
+        }
+      }
+    ]
+  },
+  "signature": "c9cb29aed477c013df667c6cea8ebc5e57fa329f37fcade4bd1dcf585e0a5730c5769f1aaa9a7f3636de7a0fa831a6298925c2de3dcd9bc534bc979e989c1606"
+}

--- a/evidence-predicate/vectors/02-independent-without-as-of/source-claim.json
+++ b/evidence-predicate/vectors/02-independent-without-as-of/source-claim.json
@@ -1,0 +1,5 @@
+{
+  "dimension": "provenance",
+  "ref": "sha256:6e0a9aa1f9d5c8ce3d545fb7b1d452f84514e93f493f94f24fa7c8180cb49ac4",
+  "state": "verified"
+}

--- a/evidence-predicate/vectors/03-forged-trusted-kid/expected.json
+++ b/evidence-predicate/vectors/03-forged-trusted-kid/expected.json
@@ -1,0 +1,10 @@
+{
+  "receipt_signature_valid": true,
+  "source_signature_valid": false,
+  "source_key_out_of_band": true,
+  "source_key_distinct": true,
+  "source_control_domain_distinct": true,
+  "independent_corroboration": false,
+  "reason": "source_signature_invalid",
+  "receipt_digest": "sha256:885bb9659cdf3412028ec0d9f42c74099bbd48ae1012d721eaadfa30ca02451d"
+}

--- a/evidence-predicate/vectors/03-forged-trusted-kid/receipt.json
+++ b/evidence-predicate/vectors/03-forged-trusted-kid/receipt.json
@@ -1,0 +1,29 @@
+{
+  "type": "scopeblind.receipt.v1",
+  "algorithm": "ed25519",
+  "kid": "test:manager:meridian:ed25519",
+  "issuer": "manager:meridian",
+  "issued_at": "2026-07-11T12:00:00Z",
+  "payload": {
+    "decision": "deny",
+    "action": {
+      "kind": "trade.submit",
+      "target": "restricted-security"
+    },
+    "receipt_id": "evidence-03",
+    "evidence": [
+      {
+        "dimension": "provenance",
+        "state": "verified",
+        "source": {
+          "authority": "custodian:demo",
+          "ref": "sha256:6e0a9aa1f9d5c8ce3d545fb7b1d452f84514e93f493f94f24fa7c8180cb49ac4",
+          "kid": "test:custodian:demo:ed25519",
+          "sig": "8d64bce9e908810d709d67d3d6627240f00f2380e53006b32bab49d16b29245f4f0dd6cdd62f36320475842015c428725b6cbf56066f5f074c93627d0d17bc07"
+        },
+        "as_of": "2026-07-11T11:59:00Z"
+      }
+    ]
+  },
+  "signature": "2f9bf1de2032a5c64c285f93384b48e1c63d96e77b9ee2cc4219110bc59380d58055941044eb32ddbcdd690d657a243a91ca5503e3aa4d128920a672b9e69507"
+}

--- a/evidence-predicate/vectors/03-forged-trusted-kid/source-claim.json
+++ b/evidence-predicate/vectors/03-forged-trusted-kid/source-claim.json
@@ -1,0 +1,6 @@
+{
+  "dimension": "provenance",
+  "ref": "sha256:6e0a9aa1f9d5c8ce3d545fb7b1d452f84514e93f493f94f24fa7c8180cb49ac4",
+  "state": "verified",
+  "as_of": "2026-07-11T11:59:00Z"
+}

--- a/evidence-predicate/vectors/04-self-corroboration/expected.json
+++ b/evidence-predicate/vectors/04-self-corroboration/expected.json
@@ -1,0 +1,10 @@
+{
+  "receipt_signature_valid": true,
+  "source_signature_valid": true,
+  "source_key_out_of_band": true,
+  "source_key_distinct": false,
+  "source_control_domain_distinct": false,
+  "independent_corroboration": false,
+  "reason": "source_key_not_independent",
+  "receipt_digest": "sha256:c4cd8bf4619f468d0548b784703f52796c32b4d58424fd6dd3ee8f32c0023cbe"
+}

--- a/evidence-predicate/vectors/04-self-corroboration/receipt.json
+++ b/evidence-predicate/vectors/04-self-corroboration/receipt.json
@@ -1,0 +1,29 @@
+{
+  "type": "scopeblind.receipt.v1",
+  "algorithm": "ed25519",
+  "kid": "test:manager:meridian:ed25519",
+  "issuer": "manager:meridian",
+  "issued_at": "2026-07-11T12:00:00Z",
+  "payload": {
+    "decision": "deny",
+    "action": {
+      "kind": "trade.submit",
+      "target": "restricted-security"
+    },
+    "receipt_id": "evidence-04",
+    "evidence": [
+      {
+        "dimension": "provenance",
+        "state": "verified",
+        "source": {
+          "authority": "manager:meridian",
+          "ref": "sha256:6e0a9aa1f9d5c8ce3d545fb7b1d452f84514e93f493f94f24fa7c8180cb49ac4",
+          "kid": "test:manager:meridian:ed25519",
+          "sig": "8d64bce9e908810d709d67d3d6627240f00f2380e53006b32bab49d16b29245f4f0dd6cdd62f36320475842015c428725b6cbf56066f5f074c93627d0d17bc07"
+        },
+        "as_of": "2026-07-11T11:59:00Z"
+      }
+    ]
+  },
+  "signature": "5eafc7f0d9dd3ec7d5aaea3a345eeab8a86b8c4211552a3cd5de0f438496a7f4a47959a3a783b7f6951a5ff797ea0a318f57a4d21a04ea1087c9525a72373d0a"
+}

--- a/evidence-predicate/vectors/04-self-corroboration/source-claim.json
+++ b/evidence-predicate/vectors/04-self-corroboration/source-claim.json
@@ -1,0 +1,6 @@
+{
+  "dimension": "provenance",
+  "ref": "sha256:6e0a9aa1f9d5c8ce3d545fb7b1d452f84514e93f493f94f24fa7c8180cb49ac4",
+  "state": "verified",
+  "as_of": "2026-07-11T11:59:00Z"
+}


### PR DESCRIPTION
## Summary

Adds a dependency-free conformance suite for the proposed signed `evidence` predicate.

The suite proves four reliance outcomes:

1. an independently pinned custodian source is accepted;
2. an absent `as_of` is omitted from the signed claim;
3. a copied trusted `kid` with a forged signature is rejected; and
4. receipt-signer self-corroboration is rejected even when the source signature is valid.

It also rejects the structural anti-pattern `as_of: null` and adds the suite to the repository's GitHub Actions workflow.

## Trust Model

A source signature is not independently corroborating merely because it verifies. The verifier requires an out-of-band trust policy, a source public key distinct from the receipt signing key, and a source control domain distinct from the receipt signer.

## Verification

```bash
./evidence-predicate/run.sh
```

Result: all four signed vectors and the nullable-`as_of` negative fixture pass.

## Existing Repository Limitation

The pre-existing general `./conformance/run.sh` still reports its independent gaps: three implementation drivers are stubs and the local `protect-mcp` driver emits zero receipts. This PR does not mask or change those outcomes.
