### PR TITLE
fix(conformance): make the gate actually gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# run.sh writes driver output here. It is regenerated on every run and can
+# contain node compile caches, so it should never be committed.
+receipts/

--- a/conformance/check_chain.py
+++ b/conformance/check_chain.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Chain order, parent-hash linkage, and expected outcomes.
+
+Split out of verify.sh so it can be read and tested on its own.
+
+What changed and why: check 3 previously computed the expected parent digest
+and then discarded it, accepting any non-empty parent_receipt_hash. Meanwhile
+expected/chain.jsonl and the fixtures' expected_decision were read by no code
+in the repository at all. An implementation could ignore the Cedar policy,
+emit four correctly signed receipts with arbitrary decisions, and be reported
+conformant. See issue #13.
+"""
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+
+def load_receipts(receipts_dir: Path):
+    receipts = [json.loads(f.read_text()) for f in sorted(receipts_dir.glob("*.json"))]
+    receipts.sort(key=lambda r: r.get("sequence", 0))
+    return receipts
+
+
+def load_expected_chain(repo: Path, errors: list):
+    """The canonical chain the README has always said check 3 compares against."""
+    path = repo / "expected" / "chain.jsonl"
+    if not path.exists():
+        errors.append("expected/chain.jsonl is missing; cannot verify outcomes")
+        return []
+    steps = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if line:
+            steps.append(json.loads(line))
+    return steps
+
+
+def check_fixture_agreement(repo: Path, expected_chain: list, errors: list):
+    """Guard the two fixture sources against drifting apart.
+
+    If chain.jsonl and the fixtures disagree about an expected decision, neither
+    can be authoritative, and the suite should say so rather than silently pick
+    one and report a pass.
+    """
+    fixtures = {}
+    for f in sorted((repo / "fixtures" / "inputs").glob("*.json")):
+        data = json.loads(f.read_text())
+        fixtures[data.get("sequence")] = data
+
+    for step in expected_chain:
+        seq = step.get("sequence")
+        fixture = fixtures.get(seq)
+        if fixture is None:
+            errors.append(f"chain.jsonl step {seq} has no matching fixture")
+        elif fixture.get("expected_decision") != step.get("decision"):
+            errors.append(
+                f"fixture/chain disagreement at sequence {seq}: fixture expects "
+                f"{fixture.get('expected_decision')!r}, chain.jsonl expects "
+                f"{step.get('decision')!r}"
+            )
+
+
+def field(receipt: dict, *names):
+    """Receipts carry these flat or inside payload, depending on the shape."""
+    for name in names:
+        if name in receipt:
+            return receipt[name]
+    payload = receipt.get("payload")
+    if isinstance(payload, dict):
+        for name in names:
+            if name in payload:
+                return payload[name]
+    return None
+
+
+def canonical_form(receipt: dict) -> str:
+    return json.dumps(
+        {k: v for k, v in receipt.items() if k not in ("signature", "public_key")},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def check_outcomes(receipt: dict, step: dict, index: int, errors: list):
+    for key, names in (
+        ("tool_name", ("tool_name", "tool")),
+        ("decision", ("decision",)),
+        ("policy_id", ("policy_id",)),
+    ):
+        want = step.get(key)
+        got = field(receipt, *names)
+        if want is not None and got != want:
+            errors.append(f"receipt {index}: {key} is {got!r}, expected {want!r}")
+
+
+def check_linkage(receipt: dict, prev_canonical, index: int, errors: list):
+    parent = receipt.get("parent_receipt_hash")
+    if index == 0:
+        if parent not in (None, ""):
+            errors.append(
+                f"receipt 0: genesis should have null/empty parent_receipt_hash, got {parent!r}"
+            )
+        return
+    if not parent:
+        errors.append(f"receipt {index}: missing parent_receipt_hash")
+        return
+    if prev_canonical is None:
+        return
+    # Implementations may truncate the parent hash, so a prefix match is
+    # accepted. That is what the original comment intended; the computed value
+    # was simply never compared against anything.
+    expected = hashlib.sha256(prev_canonical.encode()).hexdigest()
+    supplied = str(parent).lower()
+    if supplied.startswith("sha256:"):
+        supplied = supplied[len("sha256:"):]
+    if not expected.startswith(supplied):
+        errors.append(
+            f"receipt {index}: parent_receipt_hash {parent!r} does not match the "
+            f"predecessor digest {expected[:16]}..."
+        )
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: check_chain.py <receipts_dir> <repo_root>", file=sys.stderr)
+        return 2
+
+    receipts_dir = Path(sys.argv[1])
+    repo = Path(sys.argv[2])
+
+    errors: list = []
+    receipts = load_receipts(receipts_dir)
+    expected_chain = load_expected_chain(repo, errors)
+    check_fixture_agreement(repo, expected_chain, errors)
+
+    if expected_chain and len(receipts) != len(expected_chain):
+        errors.append(f"expected {len(expected_chain)} receipts, got {len(receipts)}")
+
+    prev_canonical = None
+    for index, receipt in enumerate(receipts):
+        expected_seq = index + 1
+        if receipt.get("sequence") != expected_seq:
+            errors.append(
+                f"receipt {index}: sequence {receipt.get('sequence')} != expected {expected_seq}"
+            )
+        if index < len(expected_chain):
+            check_outcomes(receipt, expected_chain[index], index, errors)
+        check_linkage(receipt, prev_canonical, index, errors)
+        prev_canonical = canonical_form(receipt)
+
+    if errors:
+        for error in errors:
+            print(f"  {error}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conformance/run.sh
+++ b/conformance/run.sh
@@ -17,6 +17,14 @@ GREEN="$(printf '\033[0;32m')"
 RED="$(printf '\033[0;31m')"
 NC="$(printf '\033[0m')"
 
+# Track outcomes so the script's exit status reflects the verdict it prints.
+# Previously the loop ended without an exit, so run.sh returned the status of
+# its last echo: CI stayed green while every implementation was reported
+# NON-CONFORMANT. A gate that prints the right answer and returns 0 is not a
+# gate. Reported in #13.
+FAILED=0
+CHECKED=0
+
 for impl_dir in implementations/*/; do
     impl="$(basename "$impl_dir")"
     echo ""
@@ -33,14 +41,32 @@ for impl_dir in implementations/*/; do
     RC=$?
     if [ "$RC" -ne 0 ]; then
         echo "${RED}FAIL${NC}: $impl run.sh exited $RC"
+        FAILED=$((FAILED+1))
         continue
     fi
     echo "--- verifying $impl output ---"
     ./conformance/verify.sh "receipts/$impl"
     V=$?
+    CHECKED=$((CHECKED+1))
     if [ "$V" -eq 0 ]; then
         echo "${GREEN}CONFORMANT${NC}: $impl"
     else
         echo "${RED}NON-CONFORMANT${NC}: $impl"
+        FAILED=$((FAILED+1))
     fi
 done
+
+echo ""
+echo "==========================================="
+echo "  $CHECKED implementation(s) verified, $FAILED failed"
+echo "==========================================="
+
+# An empty run is a failure too. If no implementation was exercised, the suite
+# has proved nothing, and reporting success would repeat the bug above in a
+# different costume.
+if [ "$CHECKED" -eq 0 ]; then
+    echo "${RED}ERROR${NC}: no implementation was verified"
+    exit 1
+fi
+
+[ "$FAILED" -eq 0 ]

--- a/conformance/verify.sh
+++ b/conformance/verify.sh
@@ -94,64 +94,36 @@ done
 # ----- Check 2: signature verification ----------------------------------------
 echo ""
 echo "=== Check 2: @veritasacta/verify signatures ==="
-npx --yes @veritasacta/verify "$RECEIPTS_DIR"/*.json >/dev/null 2>&1
+# The verifier needs a key for receipts that do not carry an inline public
+# key. Without one it exits non-zero with no_public_key, which this script
+# previously reported as a failed signature. That is the difference between
+# "this receipt was tampered with" and "I was not told what to trust", and
+# conflating them makes the check useless. Key is the published fixture seed's
+# public half (fixtures/keys/README.md). Reported in #13.
+CONFORMANCE_KEY="${CONFORMANCE_KEY:-4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29}"
+npx --yes @veritasacta/verify --key "$CONFORMANCE_KEY" "$RECEIPTS_DIR"/*.json >/dev/null 2>&1
 RC=$?
 case "$RC" in
     0) pass "all signatures verify (exit 0)" ;;
-    1) fail "one or more signatures failed (exit 1 = tampered)" ;;
-    2) fail "malformed receipt (exit 2)" ;;
+    1) fail "one or more signatures failed verification (exit 1)" ;;
+    2) fail "malformed or unrecognised receipt (exit 2)" ;;
     *) fail "verifier exited with unexpected code $RC" ;;
 esac
 
-# ----- Check 3: chain integrity (ordered sequence + parent hash linkage) ------
+# ----- Check 3: chain integrity + expected outcomes ---------------------------
+# Previously this checked only that parent_receipt_hash was non-empty. It
+# computed the expected hash and discarded it, so any constant string passed,
+# and expected/chain.jsonl and the fixtures' expected_decision were read by no
+# code at all. An implementation could ignore the policy, emit four correctly
+# signed receipts with arbitrary decisions, and be reported conformant.
+# Reported in #13.
 echo ""
-echo "=== Check 3: chain order + parent-hash linkage ==="
-python3 - <<PY
-import hashlib, json, os, sys
-from pathlib import Path
-
-d = Path("$RECEIPTS_DIR")
-receipts = []
-for f in sorted(d.glob("*.json")):
-    receipts.append(json.loads(f.read_text()))
-
-# Sort by sequence if present, else by filename order
-receipts.sort(key=lambda r: r.get("sequence", 0))
-
-errors = []
-prev_canonical_hash = None
-for i, r in enumerate(receipts):
-    expected_seq = i + 1
-    if r.get("sequence") != expected_seq:
-        errors.append(f"receipt {i}: sequence {r.get('sequence')} != expected {expected_seq}")
-    # Compute canonical form (JCS-lite: sorted keys, separators, no whitespace)
-    canonical = json.dumps(
-        {k: v for k, v in r.items() if k not in ("signature", "public_key")},
-        sort_keys=True, separators=(",", ":")
-    )
-    # Check parent linkage
-    if i == 0:
-        if r.get("parent_receipt_hash") not in (None, ""):
-            errors.append(f"receipt 0: genesis should have null/empty parent_receipt_hash, got {r.get('parent_receipt_hash')}")
-    else:
-        # Implementations may use different prefix lengths for the parent hash
-        # (e.g., first 16 hex chars). Accept any prefix match of the expected hash.
-        expected_hash = hashlib.sha256(prev_canonical_hash.encode()).hexdigest() if prev_canonical_hash else None
-        # Some implementations compute hash differently; just verify *some* non-null link exists
-        if not r.get("parent_receipt_hash"):
-            errors.append(f"receipt {i}: missing parent_receipt_hash")
-    prev_canonical_hash = canonical
-
-if errors:
-    for e in errors:
-        print(f"  {e}")
-    sys.exit(1)
-sys.exit(0)
-PY
+echo "=== Check 3: chain order, parent-hash linkage, expected outcomes ==="
+python3 "$REPO_ROOT/conformance/check_chain.py" "$RECEIPTS_DIR" "$REPO_ROOT"
 if [ "$?" -eq 0 ]; then
-    pass "chain order + linkage"
+    pass "chain order, linkage, and expected outcomes"
 else
-    fail "chain order + linkage"
+    fail "chain order, linkage, and expected outcomes"
 fi
 
 # ----- Summary ----------------------------------------------------------------


### PR DESCRIPTION
Addresses findings 1, 3 and 5 from #13, reported by @arian-gogani. He was right on every one I checked, and I verified each against a clean clone before changing anything.

Deliberately does **not** include the receipt-shape decision from finding 4. More on that below.

## What was broken

**The gate did not gate.** `run.sh` had no `exit` after its loop, so the script's status was that of the last `echo`. CI has been green this whole time while every implementation was reported NON-CONFORMANT. On the current tree it now exits 1:

```
FAIL: aps-governance-hook run.sh exited 77
FAIL: protect-mcp-adk run.sh exited 77
NON-CONFORMANT: protect-mcp
FAIL: sb-runtime run.sh exited 77
  1 implementation(s) verified, 4 failed
exit=1
```

That is the real state of the suite, and it should have been visible months ago.

**Check 2 could not tell a bad signature from a missing key.** It never passed `--key`, so the verifier exited with `no_public_key` and this script reported "one or more signatures failed (exit 1 = tampered)". Those are completely different problems. It now passes the published fixture key, overridable via `CONFORMANCE_KEY`.

**Check 3 checked almost nothing.** It computed the expected parent digest and then discarded it, accepting any non-empty `parent_receipt_hash`. Meanwhile `expected/chain.jsonl` and the fixtures' `expected_decision` were read by no code anywhere in the repository, despite the README promising the first.

The consequence, which is the part that matters: an implementation could ignore the Cedar policy entirely, emit four correctly signed receipts with arbitrary decisions, and be reported conformant.

## What check 3 does now

Compares each receipt against `expected/chain.jsonl` on `tool_name`, `decision` and `policy_id`. Compares the parent hash against the predecessor digest, accepting a prefix so truncating implementations still pass, which is what the original comment intended before the computed value was dropped on the floor. And cross-checks `chain.jsonl` against the fixtures' `expected_decision`, so if those two sources ever disagree the suite says so instead of silently picking one.

Moved to `conformance/check_chain.py` so it can be read and run on its own.

## Demonstrated, not asserted

On a receipt set that allows the destructive `rm -rf /` fixture the policy forbids:

```
  OLD check 3 -> PASS (exit 0)
  NEW check 3 -> FAIL (exit 1)
      receipt 2: decision is 'allow', expected 'deny'
```

And on a set using a constant string for every parent hash:

```
  OLD -> PASS (exit 0)
  NEW -> FAIL (exit 1)
```

## Also

A `.gitignore` for `receipts/`. `run.sh` writes there, it is untracked, and it can contain node compile caches. I nearly committed several thousand of them while testing this.

## Not in this PR

Finding 4, that check 1 and check 2 accept disjoint sets of receipts, is real: the schema requires `pubkey` and `payload.type`, while this repository's own reference receipts in `aps-gateway-enforcement/` carry `kid` and a top-level `type: decision_receipt`, so the schema rejects the receipts we ship.

That needs a decision about which shape the suite accepts rather than a quiet edit inside a fix PR. Answering it in #12 so the second implementation is not blocked on it.

Finding 2, that the reference driver calls `protect-mcp evaluate` and `protect-mcp sign`, is also real. There is no `sign` subcommand in the CLI at all. Separate fix.
